### PR TITLE
Fix problems found by SpyGlass lint

### DIFF
--- a/src/soc/hw/compute_tile_dm/compute_tile_dm.core
+++ b/src/soc/hw/compute_tile_dm/compute_tile_dm.core
@@ -16,7 +16,7 @@ depend =
   optimsoc:base:functions
 
 [fileset src_files]
-file_type = systemVerilogSource
+file_type = systemVerilogSource-2009
 usage = sim synth
 files =
   verilog/compute_tile_dm.sv

--- a/src/soc/hw/compute_tile_dm/verilog/compute_tile_dm.sv
+++ b/src/soc/hw/compute_tile_dm/verilog/compute_tile_dm.sv
@@ -40,7 +40,10 @@ module compute_tile_dm
 
     parameter DEBUG_BASEID = 'x,
 
-    parameter MEM_FILE = 'x
+    parameter MEM_FILE = 'x,
+
+    localparam CHANNELS = CONFIG.NOC_CHANNELS,
+    localparam FLIT_WIDTH = CONFIG.NOC_FLIT_WIDTH
     )
    (
    input                                 dii_flit [1:0] debug_ring_in,
@@ -76,9 +79,6 @@ module compute_tile_dm
    );
 
    import functions::*;
-
-   localparam CHANNELS = CONFIG.NOC_CHANNELS;
-   localparam FLIT_WIDTH = CONFIG.NOC_FLIT_WIDTH;
 
    localparam NR_MASTERS = CONFIG.CORES_PER_TILE * 2 + 1;
    localparam NR_SLAVES = 4;

--- a/src/soc/hw/networkadapter_ct/networkadapter_ct.core
+++ b/src/soc/hw/networkadapter_ct/networkadapter_ct.core
@@ -16,7 +16,7 @@ depend =
 # lisnoc_add_file router/lisnoc_router_output_arbiter.v
 
 [fileset src_files]
-file_type = systemVerilogSource
+file_type = systemVerilogSource-2009
 usage = sim synth
 files =
   verilog/networkadapter_ct.sv

--- a/src/soc/hw/networkadapter_ct/verilog/networkadapter_ct.sv
+++ b/src/soc/hw/networkadapter_ct/verilog/networkadapter_ct.sv
@@ -35,7 +35,10 @@ module networkadapter_ct
     parameter config_t CONFIG = 'x,
 
     parameter TILEID = 'x,
-    parameter COREBASE = 'x
+    parameter COREBASE = 'x,
+
+    localparam CHANNELS = CONFIG.NOC_CHANNELS,
+    localparam FLIT_WIDTH = CONFIG.NOC_FLIT_WIDTH
     )
    (
 `ifdef OPTIMSOC_CLOCKDOMAINS
@@ -86,9 +89,6 @@ module networkadapter_ct
 
     output [1:0]                          irq
     );
-
-   localparam CHANNELS = CONFIG.NOC_CHANNELS;
-   localparam FLIT_WIDTH = CONFIG.NOC_FLIT_WIDTH;
 
    // Those are the actual channels from the modules
    localparam MODCHANNELS = 4;

--- a/src/soc/hw/noc/buffer.core
+++ b/src/soc/hw/noc/buffer.core
@@ -6,9 +6,7 @@ depend =
   optimsoc:base:config
 
 [fileset src_files]
-file_type = systemVerilogSource
+file_type = systemVerilogSource-2009
 usage = sim synth
 files =
   verilog/noc_buffer.sv
-
-

--- a/src/soc/hw/noc/verilog/noc_buffer.sv
+++ b/src/soc/hw/noc/verilog/noc_buffer.sv
@@ -30,8 +30,10 @@
 module noc_buffer
   #(parameter FLIT_WIDTH = 32,
     parameter DEPTH = 16,
-    parameter FULLPACKET = 0)
-   (
+    parameter FULLPACKET = 0,
+
+    localparam ID_W = $clog2(DEPTH) // the width of the index
+   )(
     input                       clk,
     input                       rst,
 
@@ -49,8 +51,6 @@ module noc_buffer
 
     output [ID_W-1:0]           packet_size
     );
-
-   localparam ID_W = $clog2(DEPTH); // the width of the index
 
    // internal shift register
    reg [DEPTH-1:0][FLIT_WIDTH:0] data;
@@ -88,9 +88,9 @@ module noc_buffer
 
          always @(posedge clk)
            if(rst)
-             data_last_buf = 0;
+             data_last_buf <= 0;
            else if(in_fire)
-             data_last_buf = {data_last_buf, in_last && in_valid};
+             data_last_buf <= {data_last_buf, in_last && in_valid};
 
          // extra logic to get the packet size in a stable manner
          assign data_last_shifted = data_last_buf << DEPTH - 1 - rp;

--- a/src/soc/hw/noc/verilog/noc_demux.sv
+++ b/src/soc/hw/noc/verilog/noc_demux.sv
@@ -54,9 +54,9 @@ module noc_demux
 
    wire [2:0]                                         packet_class;
    reg [CHANNELS-1:0]                                 select;
-   
+
    assign packet_class = in_flit[NOC_CLASS_MSB:NOC_CLASS_LSB];
-   
+
    always @(*) begin : gen_select
       select = MAPPING[8*packet_class +: CHANNELS];
       if (select == 0) begin
@@ -66,7 +66,7 @@ module noc_demux
 
    assign out_flit = {CHANNELS{in_flit}};
    assign out_last = {CHANNELS{in_last}};
-   
+
    always @(*) begin
       nxt_active = active;
 
@@ -89,14 +89,14 @@ module noc_demux
          end
       end
    end
-   
+
    always @(posedge clk)
      if (rst) begin
         active <= '0;
      end else begin
         active <= nxt_active;
      end
-   
+
 endmodule // noc_demux
 
 


### PR DESCRIPTION
Explicitly set file type to SV-2009 if we use localparam inside the
ANSI-style ports list, as this is the first version which supports this.