### PR TITLE
[WIP] Ethernet tile

### DIFF
--- a/examples/fpga/nexys4ddr/compute_tile_ethernet/axi_ethernet_0.core
+++ b/examples/fpga/nexys4ddr/compute_tile_ethernet/axi_ethernet_0.core
@@ -1,0 +1,10 @@
+CAPI=1
+[main]
+name = optimsoc:examples:compute_tile_ethernet_nexys4ddr-axi_ethernet_0
+depend =
+
+[fileset xci]
+usage = vivado
+file_type = xci
+files =
+  ip/axi_ethernet_0.xci

--- a/examples/fpga/nexys4ddr/compute_tile_ethernet/axi_fifo_mm_s_0.core
+++ b/examples/fpga/nexys4ddr/compute_tile_ethernet/axi_fifo_mm_s_0.core
@@ -1,0 +1,10 @@
+CAPI=1
+[main]
+name = optimsoc:examples:compute_tile_ethernet_nexys4ddr-axi_fifo_mm_s_0
+depend =
+
+[fileset xci]
+usage = vivado
+file_type = xci
+files =
+  ip/axi_fifo_mm_s_0.xci

--- a/examples/fpga/nexys4ddr/compute_tile_ethernet/compute_tile_ethernet_nexys4ddr.core
+++ b/examples/fpga/nexys4ddr/compute_tile_ethernet/compute_tile_ethernet_nexys4ddr.core
@@ -1,0 +1,34 @@
+CAPI=1
+[main]
+name = optimsoc:examples:compute_tile_ethernet_nexys4ddr
+description = "Xilinx/Digilent Nexys4 DDR board with compute tile and Ethernet support"
+depend =
+  optimsoc:examples:compute_tile_ethernet_nexys4ddr-axi_ethernet_0
+  optimsoc:examples:compute_tile_ethernet_nexys4ddr-axi_fifo_mm_s_0
+  optimsoc:examples:compute_tile_ethernet_nexys4ddr-mii_to_rmii_0
+  wallento:boards:nexys4ddr
+  wallento:svchannels:nasti
+  wallento:svchannels:wishbone
+  wallento:wb2axi:wb2axi
+  optimsoc:tile:compute_tile_dm
+  optimsoc:debug:debug_interface
+  opensocdebug:interconnect:debug_ring
+  glip:backend:uart
+  optimsoc:base:config
+
+backend = vivado
+
+[fileset rtl_files]
+file_type = systemVerilogSource
+usage = sim synth
+files =
+  rtl/verilog/compute_tile_dm_ethernet_nexys4.sv
+
+[vivado]
+part = "xc7a100tcsg324-1"
+hw_device = xc7a100t_0
+
+[parameter NUM_CORES]
+datatype = int
+paramtype = vlogparam
+scope = public

--- a/examples/fpga/nexys4ddr/compute_tile_ethernet/ip/axi_ethernet_0.xci
+++ b/examples/fpga/nexys4ddr/compute_tile_ethernet/ip/axi_ethernet_0.xci
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spirit:design xmlns:xilinx="http://www.xilinx.com" xmlns:spirit="http://www.spiritconsortium.org/XMLSchema/SPIRIT/1685-2009" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <spirit:vendor>xilinx.com</spirit:vendor>
+  <spirit:library>xci</spirit:library>
+  <spirit:name>unknown</spirit:name>
+  <spirit:version>1.0</spirit:version>
+  <spirit:componentInstances>
+    <spirit:componentInstance>
+      <spirit:instanceName>axi_ethernet_0</spirit:instanceName>
+      <spirit:componentRef spirit:vendor="xilinx.com" spirit:library="ip" spirit:name="axi_ethernet" spirit:version="7.0"/>
+      <spirit:configurableElementValues>
+        <spirit:configurableElementValue spirit:referenceId="ADDRBLOCK_BASE_ADDRESS.S_AXI.Reg0">0x00000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.AXIS_CLK.ASSOCIATED_BUSIF">m_axis_rxd:m_axis_rxs:s_axis_txc:s_axis_txd</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.AXIS_CLK.ASSOCIATED_RESET">axi_rxd_arstn:axi_rxs_arstn:axi_txc_arstn:axi_txd_arstn</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.AXIS_CLK.CLK_DOMAIN"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.AXIS_CLK.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.AXIS_CLK.PHASE">0.000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.GTX_CLK.ASSOCIATED_BUSIF"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.GTX_CLK.ASSOCIATED_RESET"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.GTX_CLK.CLK_DOMAIN"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.GTX_CLK.FREQ_HZ">125000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.GTX_CLK.PHASE">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.S_AXI_LITE_CLK.ASSOCIATED_BUSIF">s_axi</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.S_AXI_LITE_CLK.ASSOCIATED_RESET">s_axi_lite_resetn</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.S_AXI_LITE_CLK.CLK_DOMAIN"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.S_AXI_LITE_CLK.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLK.S_AXI_LITE_CLK.PHASE">0.000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.INTR.INTERRUPT.PortWidth">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.INTR.INTERRUPT.SENSITIVITY">LEVEL_HIGH</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.INTR.MAC_IRQ.PortWidth">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.INTR.MAC_IRQ.SENSITIVITY">EDGE_RISING</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.MDIO.BOARD.ASSOCIATED_PARAM">MDIO_BOARD_INTERFACE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.MII.BOARD.ASSOCIATED_PARAM">ETHERNET_BOARD_INTERFACE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.CLK_DOMAIN"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.HAS_TKEEP">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.HAS_TLAST">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.HAS_TREADY">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.HAS_TSTRB">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.LAYERED_METADATA">undef</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.PHASE">0.000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.TDATA_NUM_BYTES">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.TDEST_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.TID_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.TUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.CLK_DOMAIN"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.HAS_TKEEP">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.HAS_TLAST">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.HAS_TREADY">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.HAS_TSTRB">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.LAYERED_METADATA">undef</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.PHASE">0.000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.TDATA_NUM_BYTES">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.TDEST_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.TID_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.TUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.RST.AXI_RXD_ARSTN.POLARITY">ACTIVE_LOW</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.RST.AXI_RXS_ARSTN.POLARITY">ACTIVE_LOW</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.RST.AXI_TXC_ARSTN.POLARITY">ACTIVE_LOW</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.RST.AXI_TXD_ARSTN.POLARITY">ACTIVE_LOW</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.RST.PHY_RST_N.BOARD.ASSOCIATED_PARAM">PHYRST_BOARD_INTERFACE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.RST.PHY_RST_N.POLARITY">ACTIVE_LOW</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.RST.S_AXI_LITE_RESETN.POLARITY">ACTIVE_LOW</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.ADDR_WIDTH">18</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.ARUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.AWUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.BUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.CLK_DOMAIN"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.DATA_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_BRESP">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_BURST">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_CACHE">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_LOCK">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_PROT">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_QOS">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_REGION">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_RRESP">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_WSTRB">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.ID_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.MAX_BURST_LENGTH">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.NUM_READ_OUTSTANDING">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.NUM_READ_THREADS">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.NUM_WRITE_OUTSTANDING">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.NUM_WRITE_THREADS">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.PHASE">0.000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.PROTOCOL">AXI4LITE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.READ_WRITE_MODE">READ_WRITE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.RUSER_BITS_PER_BYTE">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.RUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.SUPPORTS_NARROW_BURST">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.WUSER_BITS_PER_BYTE">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXI.WUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.CLK_DOMAIN"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.HAS_TKEEP">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.HAS_TLAST">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.HAS_TREADY">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.HAS_TSTRB">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.LAYERED_METADATA">undef</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.PHASE">0.000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.TDATA_NUM_BYTES">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.TDEST_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.TID_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.TUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.CLK_DOMAIN"/>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.HAS_TKEEP">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.HAS_TLAST">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.HAS_TREADY">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.HAS_TSTRB">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.LAYERED_METADATA">undef</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.PHASE">0.000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.TDATA_NUM_BYTES">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.TDEST_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.TID_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.TUSER_WIDTH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Component_Name">axi_ethernet_0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.DIFFCLK_BOARD_INTERFACE">Custom</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.ENABLE_AVB">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.ENABLE_LVDS">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.ETHERNET_BOARD_INTERFACE">Custom</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.EnableAsyncSGMII">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Enable_1588">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Enable_1588_1step">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Enable_Pfc">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Frame_Filter">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.GTinEx">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Include_IO">true</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.MCAST_EXTEND">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.MDIO_BOARD_INTERFACE">Custom</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Number_of_Table_Entries">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.PHYADDR">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.PHYRST_BOARD_INTERFACE">Custom</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.PHY_TYPE">MII</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.RXCSUM">None</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.RXMEM">4k</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.RXVLAN_STRP">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.RXVLAN_TAG">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.RXVLAN_TRAN">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.SIMULATION_MODE">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Statistics_Counters">true</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Statistics_Reset">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Statistics_Width">64bit</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.SupportLevel">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.TIMER_CLK_PERIOD">4000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.TXCSUM">None</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.TXMEM">4k</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.TXVLAN_STRP">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.TXVLAN_TAG">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.TXVLAN_TRAN">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Timer_Format">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.TransceiverControl">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.USE_BOARD_FLOW">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.axiliteclkrate">50</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.axisclkrate">50</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.drpclkrate">50.0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.gt_type">GTH</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.gtlocation">X0Y0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.gtrefclkrate">125</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.gtrefclksrc">clk0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.lvdsclkrate">125</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.processor_mode">true</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.rxlane0_placement">DIFF_PAIR_0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.rxlane1_placement">DIFF_PAIR_1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.rxnibblebitslice0used">true</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.speed_1_2p5">1G</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.tx_in_upper_nibble">true</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.txlane0_placement">DIFF_PAIR_0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.txlane1_placement">DIFF_PAIR_1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.ARCHITECTURE">artix7</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.BOARD"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.DEVICE">xc7a100t</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.PACKAGE">csg324</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.PREFHDL">VERILOG</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SILICON_REVISION"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SIMULATOR_LANGUAGE">MIXED</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SPEEDGRADE">-1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.TEMPERATURE_GRADE"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.USE_RDI_CUSTOMIZATION">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.USE_RDI_GENERATION">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.IPCONTEXT">IP_Flow</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.IPREVISION">7</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.MANAGED">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.OUTPUTDIR">.</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SELECTEDSIMMODEL"/>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SHAREDDIR">.</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SWVERSION">2016.4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SYNTHESISFLOW">OOC_HIERARCHICAL</spirit:configurableElementValue>
+      </spirit:configurableElementValues>
+      <spirit:vendorExtensions>
+        <xilinx:componentInstanceExtensions>
+          <xilinx:configElementInfos>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.CLK.AXIS_CLK.ASSOCIATED_BUSIF" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.CLK.AXIS_CLK.ASSOCIATED_RESET" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.CLK.GTX_CLK.FREQ_HZ" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.CLK.GTX_CLK.PHASE" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.CLK.S_AXI_LITE_CLK.ASSOCIATED_BUSIF" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.CLK.S_AXI_LITE_CLK.ASSOCIATED_RESET" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.INTR.INTERRUPT.SENSITIVITY" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.INTR.MAC_IRQ.SENSITIVITY" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.MDIO.BOARD.ASSOCIATED_PARAM" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.MII.BOARD.ASSOCIATED_PARAM" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.CLK_DOMAIN" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.FREQ_HZ" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.HAS_TKEEP" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.HAS_TLAST" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.HAS_TREADY" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.HAS_TSTRB" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.PHASE" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.TDATA_NUM_BYTES" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.TDEST_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.TID_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXD.TUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.CLK_DOMAIN" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.FREQ_HZ" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.HAS_TKEEP" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.HAS_TLAST" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.HAS_TREADY" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.HAS_TSTRB" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.PHASE" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.TDATA_NUM_BYTES" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.TDEST_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.TID_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.M_AXIS_RXS.TUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.RST.AXI_RXD_ARSTN.POLARITY" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.RST.AXI_RXS_ARSTN.POLARITY" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.RST.AXI_TXC_ARSTN.POLARITY" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.RST.AXI_TXD_ARSTN.POLARITY" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.RST.PHY_RST_N.BOARD.ASSOCIATED_PARAM" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.RST.PHY_RST_N.POLARITY" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.RST.S_AXI_LITE_RESETN.POLARITY" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.ADDR_WIDTH" xilinx:valueSource="constant_prop"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.ARUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.AWUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.BUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.CLK_DOMAIN" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.DATA_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.FREQ_HZ" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_BRESP" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_BURST" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_CACHE" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_LOCK" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_PROT" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_QOS" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_REGION" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_RRESP" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.HAS_WSTRB" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.ID_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.PHASE" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.PROTOCOL" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.READ_WRITE_MODE" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.RUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXI.WUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.CLK_DOMAIN" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.FREQ_HZ" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.HAS_TKEEP" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.HAS_TLAST" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.HAS_TREADY" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.HAS_TSTRB" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.PHASE" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.TDATA_NUM_BYTES" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.TDEST_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.TID_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXC.TUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.CLK_DOMAIN" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.FREQ_HZ" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.HAS_TKEEP" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.HAS_TLAST" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.HAS_TREADY" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.HAS_TSTRB" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.PHASE" xilinx:valueSource="propagated"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.TDATA_NUM_BYTES" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.TDEST_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.TID_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="BUSIFPARAM_VALUE.S_AXIS_TXD.TUSER_WIDTH" xilinx:valueSource="constant"/>
+            <xilinx:configElementInfo xilinx:referenceId="PARAM_VALUE.Frame_Filter" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="PARAM_VALUE.PHY_TYPE" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="PARAM_VALUE.Statistics_Counters" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="PARAM_VALUE.axiliteclkrate" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="PARAM_VALUE.axisclkrate" xilinx:valueSource="user"/>
+          </xilinx:configElementInfos>
+        </xilinx:componentInstanceExtensions>
+      </spirit:vendorExtensions>
+    </spirit:componentInstance>
+  </spirit:componentInstances>
+</spirit:design>

--- a/examples/fpga/nexys4ddr/compute_tile_ethernet/ip/axi_fifo_mm_s_0.xci
+++ b/examples/fpga/nexys4ddr/compute_tile_ethernet/ip/axi_fifo_mm_s_0.xci
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spirit:design xmlns:xilinx="http://www.xilinx.com" xmlns:spirit="http://www.spiritconsortium.org/XMLSchema/SPIRIT/1685-2009" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <spirit:vendor>xilinx.com</spirit:vendor>
+  <spirit:library>xci</spirit:library>
+  <spirit:name>unknown</spirit:name>
+  <spirit:version>1.0</spirit:version>
+  <spirit:componentInstances>
+    <spirit:componentInstance>
+      <spirit:instanceName>axi_fifo_mm_s_0</spirit:instanceName>
+      <spirit:componentRef spirit:vendor="xilinx.com" spirit:library="ip" spirit:name="axi_fifo_mm_s" spirit:version="4.1"/>
+      <spirit:configurableElementValues>
+        <spirit:configurableElementValue spirit:referenceId="ADDRBLOCK_RANGE.S_AXI.Mem0">4096</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="ADDRBLOCK_RANGE.S_AXI_FULL.Mem1">4096</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.ACLK_S_AXI.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_AXI4_BASEADDR">0x80001000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_AXI4_HIGHADDR">0x80002FFF</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_AXIS_TDEST_WIDTH">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_AXIS_TID_WIDTH">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_AXIS_TUSER_WIDTH">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_BASEADDR">0x80000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_DATA_INTERFACE_TYPE">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_FAMILY">artix7</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_HAS_AXIS_TDEST">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_HAS_AXIS_TID">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_HAS_AXIS_TKEEP">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_HAS_AXIS_TSTRB">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_HAS_AXIS_TUSER">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_HIGHADDR">0x80000FFF</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_RX_FIFO_DEPTH">512</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_RX_FIFO_PE_THRESHOLD">2</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_RX_FIFO_PF_THRESHOLD">507</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_S_AXI4_DATA_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_S_AXI_ADDR_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_S_AXI_DATA_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_S_AXI_ID_WIDTH">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_TX_FIFO_DEPTH">512</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_TX_FIFO_PE_THRESHOLD">2</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_TX_FIFO_PF_THRESHOLD">507</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_USE_RX_CUT_THROUGH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_USE_RX_DATA">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_USE_TX_CTRL">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_USE_TX_CUT_THROUGH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_USE_TX_DATA">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXI4_BASEADDR">0x80001000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXI4_HIGHADDR">0x80002FFF</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXIS_TDEST_WIDTH">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXIS_TID_WIDTH">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXIS_TUSER_WIDTH">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXI_STR_RXD_PROTOCOL">XIL_AXI_STREAM_ETH_DATA</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXI_STR_RXD_TDATA_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXI_STR_TXC_PROTOCOL">XIL_AXI_STREAM_ETH_CTRL</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXI_STR_TXC_TDATA_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXI_STR_TXD_PROTOCOL">XIL_AXI_STREAM_ETH_DATA</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_AXI_STR_TXD_TDATA_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_BASEADDR">0x80000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_DATA_INTERFACE_TYPE">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_HAS_AXIS_TDEST">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_HAS_AXIS_TID">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_HAS_AXIS_TKEEP">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_HAS_AXIS_TSTRB">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_HAS_AXIS_TUSER">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_HIGHADDR">0x80000FFF</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_RX_FIFO_DEPTH">512</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_RX_FIFO_PE_THRESHOLD">2</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_RX_FIFO_PF_THRESHOLD">507</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_SELECT_XPM">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_S_AXI4_DATA_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_S_AXI_ADDR_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_S_AXI_DATA_WIDTH">32</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_S_AXI_ID_WIDTH">4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_S_AXI_PROTOCOL">AXI4LITE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_TX_FIFO_DEPTH">512</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_TX_FIFO_PE_THRESHOLD">2</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_TX_FIFO_PF_THRESHOLD">507</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_USE_RX_CUT_THROUGH">false</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_USE_RX_DATA">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_USE_TX_CTRL">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_USE_TX_CUT_THROUGH">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_USE_TX_DATA">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Component_Name">axi_fifo_mm_s_0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.ARCHITECTURE">artix7</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.BOARD"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.DEVICE">xc7a100t</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.PACKAGE">csg324</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.PREFHDL">VERILOG</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SILICON_REVISION"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SIMULATOR_LANGUAGE">MIXED</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SPEEDGRADE">-1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.TEMPERATURE_GRADE"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.USE_RDI_CUSTOMIZATION">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.USE_RDI_GENERATION">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.IPCONTEXT">IP_Flow</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.IPREVISION">8</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.MANAGED">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.OUTPUTDIR">.</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SELECTEDSIMMODEL"/>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SHAREDDIR">.</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SWVERSION">2016.4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SYNTHESISFLOW">OUT_OF_CONTEXT</spirit:configurableElementValue>
+      </spirit:configurableElementValues>
+      <spirit:vendorExtensions>
+        <xilinx:componentInstanceExtensions>
+          <xilinx:configElementInfos>
+            <xilinx:configElementInfo xilinx:referenceId="PARAM_VALUE.C_USE_RX_CUT_THROUGH" xilinx:valueSource="user"/>
+            <xilinx:configElementInfo xilinx:referenceId="PARAM_VALUE.C_USE_TX_CUT_THROUGH" xilinx:valueSource="user"/>
+          </xilinx:configElementInfos>
+        </xilinx:componentInstanceExtensions>
+      </spirit:vendorExtensions>
+    </spirit:componentInstance>
+  </spirit:componentInstances>
+</spirit:design>

--- a/examples/fpga/nexys4ddr/compute_tile_ethernet/ip/mii_to_rmii_0.xci
+++ b/examples/fpga/nexys4ddr/compute_tile_ethernet/ip/mii_to_rmii_0.xci
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spirit:design xmlns:xilinx="http://www.xilinx.com" xmlns:spirit="http://www.spiritconsortium.org/XMLSchema/SPIRIT/1685-2009" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <spirit:vendor>xilinx.com</spirit:vendor>
+  <spirit:library>xci</spirit:library>
+  <spirit:name>unknown</spirit:name>
+  <spirit:version>1.0</spirit:version>
+  <spirit:componentInstances>
+    <spirit:componentInstance>
+      <spirit:instanceName>mii_to_rmii_0</spirit:instanceName>
+      <spirit:componentRef spirit:vendor="xilinx.com" spirit:library="ip" spirit:name="mii_to_rmii" spirit:version="2.0"/>
+      <spirit:configurableElementValues>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CLOCK.FREQ_HZ">100000000</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_FIXED_SPEED">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_INCLUDE_BUF">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_INSTANCE">mii_to_rmii_0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_SPEED_100">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_FIXED_SPEED">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_INCLUDE_BUF">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_INSTANCE">mii_to_rmii_inst</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_MODE">0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_SPEED_100">1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Component_Name">mii_to_rmii_0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.REF_CLK_BOARD_INTERFACE">Custom</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.RESET_BOARD_INTERFACE">Custom</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.RMII_BOARD_INTERFACE">Custom</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.ARCHITECTURE">artix7</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.BOARD"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.DEVICE">xc7a100t</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.PACKAGE">csg324</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.PREFHDL">VERILOG</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SILICON_REVISION"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SIMULATOR_LANGUAGE">MIXED</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.SPEEDGRADE">-1</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.TEMPERATURE_GRADE"/>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.USE_RDI_CUSTOMIZATION">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.USE_RDI_GENERATION">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.IPCONTEXT">IP_Flow</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.IPREVISION">13</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.MANAGED">TRUE</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.OUTPUTDIR">.</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SELECTEDSIMMODEL"/>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SHAREDDIR">.</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SWVERSION">2016.4</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="RUNTIME_PARAM.SYNTHESISFLOW">OUT_OF_CONTEXT</spirit:configurableElementValue>
+      </spirit:configurableElementValues>
+      <spirit:vendorExtensions>
+        <xilinx:componentInstanceExtensions>
+          <xilinx:configElementInfos>
+            <xilinx:configElementInfo xilinx:referenceId="PARAM_VALUE.C_SPEED_100" xilinx:valueSource="user"/>
+          </xilinx:configElementInfos>
+        </xilinx:componentInstanceExtensions>
+      </spirit:vendorExtensions>
+    </spirit:componentInstance>
+  </spirit:componentInstances>
+</spirit:design>

--- a/examples/fpga/nexys4ddr/compute_tile_ethernet/mii_to_rmii_0.core
+++ b/examples/fpga/nexys4ddr/compute_tile_ethernet/mii_to_rmii_0.core
@@ -1,0 +1,10 @@
+CAPI=1
+[main]
+name = optimsoc:examples:compute_tile_ethernet_nexys4ddr-mii_to_rmii_0
+depend =
+
+[fileset xci]
+usage = vivado
+file_type = xci
+files =
+  ip/mii_to_rmii_0.xci

--- a/examples/fpga/nexys4ddr/compute_tile_ethernet/rtl/verilog/compute_tile_dm_ethernet_nexys4.sv
+++ b/examples/fpga/nexys4ddr/compute_tile_ethernet/rtl/verilog/compute_tile_dm_ethernet_nexys4.sv
@@ -1,0 +1,807 @@
+/* Copyright (c) 2016 by the author(s)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * =============================================================================
+ *
+ * Toplevel: compute_tile_dm on a Nexys 4 DDR board with support for Ethernet
+ *
+ * Author(s):
+ *   Annika Fuchs <annika.fuchs@tum.de>
+ *   Stefan Wallentowitz <stefan.wallentowitz@tum.de>
+ *   Philipp Wagner <philipp.wagner@tum.de>
+ */
+
+import dii_package::dii_flit;
+import optimsoc::*;
+
+module compute_tile_dm_ethernet_nexys4
+  (
+   // 100 MHz system clock from board
+   input                 clk,
+   // Button "CPU RESET" (C12)
+   input                 cpu_resetn,
+
+   // UART; RTS and CTS are seen from the host side
+   output                uart_rxd_out,
+   input                 uart_txd_in,
+   output                uart_cts,
+   input                 uart_rts,
+
+   // DDR
+   output [12:0]         ddr2_addr,
+   output [2:0]          ddr2_ba,
+   output                ddr2_cas_n,
+   output                ddr2_ck_n,
+   output                ddr2_ck_p,
+   output                ddr2_cke,
+   output                ddr2_cs_n,
+   output [1:0]          ddr2_dm,
+   inout [15:0]          ddr2_dq,
+   inout [1:0]           ddr2_dqs_n,
+   inout [1:0]           ddr2_dqs_p,
+   output                ddr2_odt,
+   output                ddr2_ras_n,
+   output                ddr2_we_n,
+   
+   
+   // Ethernet
+    input                 eth_crsdv,
+    input                 eth_rxerr,
+    input  [1:0]          eth_rxd,
+    output [1:0]          eth_txd,
+    output                eth_txen,
+    output                eth_mdc,
+    inout                 eth_mdio,
+    output                eth_rstn,
+    output                eth_refclk,
+   
+   output [15:0] led
+   
+   );
+
+   parameter integer NUM_CORES = 1;
+   localparam integer LMEM_SIZE = 128*1024*1024;
+
+   localparam AXI_ID_WIDTH = 4;
+   localparam DDR_ADDR_WIDTH = 28;
+   localparam DDR_DATA_WIDTH = 32;
+
+   localparam base_config_t
+     BASE_CONFIG = '{ NUMTILES: 1,
+                      NUMCTS: 1,
+                      CTLIST: {{63{16'hx}}, 16'h0},
+                      CORES_PER_TILE: NUM_CORES,
+                      GMEM_SIZE: 0,
+                      GMEM_TILE: 'x,
+                      NOC_ENABLE_VCHANNELS: 0,
+                      LMEM_SIZE: LMEM_SIZE,
+                      LMEM_STYLE: EXTERNAL,
+                      ENABLE_BOOTROM: 0,
+                      BOOTROM_SIZE: 0,
+                      ENABLE_DM: 1,
+                      DM_BASE: 32'h0,
+                      DM_SIZE: LMEM_SIZE,
+                      ENABLE_PGAS: 0,
+                      PGAS_BASE: 0,
+                      PGAS_SIZE: 0,
+                      NA_ENABLE_MPSIMPLE: 1,
+                      NA_ENABLE_DMA: 1,
+                      NA_DMA_GENIRQ: 1,
+                      NA_DMA_ENTRIES: 4,
+                      USE_DEBUG: 1,
+                      DEBUG_STM: 1,
+                      DEBUG_CTM: 1
+                      };
+
+   localparam config_t CONFIG = derive_config(BASE_CONFIG);
+
+   nasti_channel
+     #(.ID_WIDTH   (AXI_ID_WIDTH),
+       .ADDR_WIDTH (DDR_ADDR_WIDTH),
+       .DATA_WIDTH (DDR_DATA_WIDTH))
+   c_axi_ddr();
+
+   wb_channel
+     #(.ADDR_WIDTH (DDR_ADDR_WIDTH),
+       .DATA_WIDTH (DDR_DATA_WIDTH))
+   c_wb_ddr();
+
+   wb_channel
+     #(.ADDR_WIDTH (32),
+       .DATA_WIDTH (32))
+     c_wb_ess();
+
+   wb_channel
+     #(.ADDR_WIDTH (32),
+       .DATA_WIDTH (32))
+     c_wb_fifo();
+
+     
+   // clocks and reset
+   // clk is the 100 MHz board clock
+   // cpu_resetn is a push button on the board (active low)
+
+   // system clock: 50 MHz
+   logic sys_clk;
+
+   // system reset
+   logic sys_rst;
+   
+   // 50 MHz fixed clock (for eth)
+   logic clk_50mhz;
+   // 50 MHz fixed clock with 45 degree phase shift (relative to clk_50mhz, 
+   // for eth phy)
+   logic clk_50mhz_45deg;
+   // 125 MHz clock
+   logic clk_125mhz;
+
+   // UART signals (naming from our point of view, i.e. from the DCE)
+   logic uart_rx, uart_tx, uart_cts_n, uart_rts_n;
+
+   // terminate NoC connection
+   logic [CONFIG.NOC_CHANNELS-1:0][CONFIG.NOC_FLIT_WIDTH-1:0] noc_in_flit;
+   logic [CONFIG.NOC_CHANNELS-1:0]                            noc_in_last;
+   logic [CONFIG.NOC_CHANNELS-1:0]                            noc_in_valid;
+   logic [CONFIG.NOC_CHANNELS-1:0]                            noc_in_ready;
+   logic [CONFIG.NOC_CHANNELS-1:0][CONFIG.NOC_FLIT_WIDTH-1:0] noc_out_flit;
+   logic [CONFIG.NOC_CHANNELS-1:0]                            noc_out_last;
+   logic [CONFIG.NOC_CHANNELS-1:0]                            noc_out_valid;
+   logic [CONFIG.NOC_CHANNELS-1:0]                            noc_out_ready;
+
+   assign noc_in_flit   = {CONFIG.NOC_FLIT_WIDTH*CONFIG.NOC_CHANNELS{1'bx}};
+   assign noc_in_last   = {CONFIG.NOC_CHANNELS{1'bx}};
+   assign noc_in_valid  = {CONFIG.NOC_CHANNELS{1'b0}};
+   assign noc_out_ready = {CONFIG.NOC_CHANNELS{1'b0}};
+
+   // Debug system
+   glip_channel c_glip_in(.clk(sys_clk));
+   glip_channel c_glip_out(.clk(sys_clk));
+
+   // XXX: does the HIM support hot-attach by now?
+   // See discussion in system_2x2_cccc_ztex
+   logic glip_com_rst, glip_ctrl_logic_rst;
+
+   // Off-chip UART communication interface for debug
+   glip_uart_toplevel
+      #(.FREQ_CLK_IO(50000000),
+        .BAUD(12000000),
+        .WIDTH(16),
+        .BUFFER_OUT_DEPTH(256*1024))
+      u_glip(
+         .clk_io(sys_clk),
+         .clk(sys_clk),
+         .rst(sys_rst),
+         .com_rst(glip_com_rst),
+         .ctrl_logic_rst(glip_ctrl_logic_rst),
+
+         .error(/* XXX: connect this to a LED */),
+
+         .fifo_out_data(c_glip_out.data),
+         .fifo_out_ready(c_glip_out.ready),
+         .fifo_out_valid(c_glip_out.valid),
+         .fifo_in_data(c_glip_in.data),
+         .fifo_in_ready(c_glip_in.ready),
+         .fifo_in_valid(c_glip_in.valid),
+
+         .uart_rx(uart_rx),
+         .uart_tx(uart_tx),
+         .uart_rts_n(uart_rts_n),
+         .uart_cts_n(uart_cts_n)
+      );
+
+   logic dbg_sys_rst, dbg_cpu_rst;
+
+   dii_flit [1:0] debug_ring_in;
+   dii_flit [1:0] debug_ring_out;
+   logic [1:0] debug_ring_in_ready;
+   logic [1:0] debug_ring_out_ready;
+
+   debug_interface
+      #(
+         .SYSTEMID    (1),
+         .NUM_MODULES (CONFIG.DEBUG_NUM_MODS)
+      )
+      u_debuginterface
+        (
+         .clk            (sys_clk),
+         .rst            (sys_rst),
+         .sys_rst        (dbg_sys_rst),
+         .cpu_rst        (dbg_cpu_rst),
+         .glip_in        (c_glip_in),
+         .glip_out       (c_glip_out),
+         .ring_out       (debug_ring_in),
+         .ring_out_ready (debug_ring_in_ready),
+         .ring_in        (debug_ring_out),
+         .ring_in_ready  (debug_ring_out_ready)
+      );
+
+
+    (* mark_debug = "true" *)   wire eth_irq;
+     
+   // Single compute tile with all memory mapped to the DRAM
+   compute_tile_dm
+      #(.CONFIG(CONFIG),
+        .DEBUG_BASEID(2)
+      )
+      u_compute_tile
+        (
+         .clk           (sys_clk),
+         .rst_cpu       (dbg_cpu_rst | sys_rst),
+         .rst_sys       (dbg_sys_rst | sys_rst),
+         .rst_dbg       (sys_rst),
+
+         .noc_in_flit   (noc_in_flit),
+         .noc_in_last   (noc_in_last),
+         .noc_in_valid  (noc_in_valid),
+         .noc_in_ready  (noc_in_ready),
+         .noc_out_flit  (noc_out_flit),
+         .noc_out_last  (noc_out_last),
+         .noc_out_valid (noc_out_valid),
+         .noc_out_ready (noc_out_ready),
+
+         .debug_ring_in(debug_ring_in),
+         .debug_ring_in_ready(debug_ring_in_ready),
+         .debug_ring_out(debug_ring_out),
+         .debug_ring_out_ready(debug_ring_out_ready),
+         
+         .eth_irq (eth_irq),
+
+         .wb_ext_adr_i  (c_wb_ddr.adr_o),
+         .wb_ext_cyc_i  (c_wb_ddr.cyc_o),
+         .wb_ext_dat_i  (c_wb_ddr.dat_o),
+         .wb_ext_sel_i  (c_wb_ddr.sel_o),
+         .wb_ext_stb_i  (c_wb_ddr.stb_o),
+         .wb_ext_we_i   (c_wb_ddr.we_o),
+         .wb_ext_cab_i  (), // XXX: this is an old signal not present in WB B3 any more!?
+         .wb_ext_cti_i  (c_wb_ddr.cti_o),
+         .wb_ext_bte_i  (c_wb_ddr.bte_o),
+         .wb_ext_ack_o  (c_wb_ddr.ack_i),
+         .wb_ext_rty_o  (c_wb_ddr.rty_i),
+         .wb_ext_err_o  (c_wb_ddr.err_i),
+         .wb_ext_dat_o  (c_wb_ddr.dat_i),
+
+         // Ethernet Subsystem Control
+         .wb_ess_adr_i  (c_wb_ess.adr_o),
+         .wb_ess_cyc_i  (c_wb_ess.cyc_o),
+         .wb_ess_dat_i  (c_wb_ess.dat_o),
+         .wb_ess_sel_i  (c_wb_ess.sel_o),
+         .wb_ess_stb_i  (c_wb_ess.stb_o),
+         .wb_ess_we_i   (c_wb_ess.we_o),
+         .wb_ess_cti_i  (c_wb_ess.cti_o),
+         .wb_ess_bte_i  (c_wb_ess.bte_o),
+         .wb_ess_ack_o  (c_wb_ess.ack_i),
+         .wb_ess_rty_o  (c_wb_ess.rty_i),
+         .wb_ess_err_o  (c_wb_ess.err_i),
+         .wb_ess_dat_o  (c_wb_ess.dat_i),
+
+         // Ethernet Subsystem Data
+         .wb_fifo_adr_i  (c_wb_fifo.adr_o),
+         .wb_fifo_cyc_i  (c_wb_fifo.cyc_o),
+         .wb_fifo_dat_i  (c_wb_fifo.dat_o),
+         .wb_fifo_sel_i  (c_wb_fifo.sel_o),
+         .wb_fifo_stb_i  (c_wb_fifo.stb_o),
+         .wb_fifo_we_i   (c_wb_fifo.we_o),
+         .wb_fifo_cti_i  (c_wb_fifo.cti_o),
+         .wb_fifo_bte_i  (c_wb_fifo.bte_o),
+         .wb_fifo_ack_o  (c_wb_fifo.ack_i),
+         .wb_fifo_rty_o  (c_wb_fifo.rty_i),
+         .wb_fifo_err_o  (c_wb_fifo.err_i),
+         .wb_fifo_dat_o  (c_wb_fifo.dat_i)
+      );
+      
+
+   // Nexys 4 board wrapper
+   nexys4ddr
+      #(
+         .NUM_UART(1)
+      )
+      u_board(
+         // FPGA/board interface
+         .clk(clk),
+         .cpu_resetn(cpu_resetn),
+
+         .uart_rxd_out(uart_rxd_out),
+         .uart_txd_in(uart_txd_in),
+         .uart_rts(uart_rts),
+         .uart_cts(uart_cts),
+
+         .ddr2_addr(ddr2_addr),
+         .ddr2_ba(ddr2_ba),
+         .ddr2_cas_n(ddr2_cas_n),
+         .ddr2_ck_n(ddr2_ck_n),
+         .ddr2_ck_p(ddr2_ck_p),
+         .ddr2_cke(ddr2_cke),
+         .ddr2_cs_n(ddr2_cs_n),
+         .ddr2_dm(ddr2_dm),
+         .ddr2_dq(ddr2_dq),
+         .ddr2_dqs_n(ddr2_dqs_n),
+         .ddr2_dqs_p(ddr2_dqs_p),
+         .ddr2_odt(ddr2_odt),
+         .ddr2_ras_n(ddr2_ras_n),
+         .ddr2_we_n(ddr2_we_n),
+
+         // system interface
+         .sys_clk     (sys_clk),
+         .sys_rst     (sys_rst),
+         
+         .clk_50mhz   (clk_50mhz),
+         .clk_50mhz_45deg (clk_50mhz_45deg),
+         .clk_125mhz(clk_125mhz),
+
+         .uart_rx     (uart_rx),
+         .uart_tx     (uart_tx),
+         .uart_rts_n  (uart_rts_n),
+         .uart_cts_n  (uart_cts_n),
+
+         .ddr_awid    (c_axi_ddr.aw_id),
+         .ddr_awaddr  (c_axi_ddr.aw_addr),
+         .ddr_awlen   (c_axi_ddr.aw_len),
+         .ddr_awsize  (c_axi_ddr.aw_size),
+         .ddr_awburst (c_axi_ddr.aw_burst),
+         .ddr_awcache (c_axi_ddr.aw_cache),
+         .ddr_awprot  (c_axi_ddr.aw_prot),
+         .ddr_awqos   (c_axi_ddr.aw_qos),
+         .ddr_awvalid (c_axi_ddr.aw_valid),
+         .ddr_awready (c_axi_ddr.aw_ready),
+         .ddr_wdata   (c_axi_ddr.w_data),
+         .ddr_wstrb   (c_axi_ddr.w_strb),
+         .ddr_wlast   (c_axi_ddr.w_last),
+         .ddr_wvalid  (c_axi_ddr.w_valid),
+         .ddr_wready  (c_axi_ddr.w_ready),
+         .ddr_bid     (c_axi_ddr.b_id),
+         .ddr_bresp   (c_axi_ddr.b_resp),
+         .ddr_bvalid  (c_axi_ddr.b_valid),
+         .ddr_bready  (c_axi_ddr.b_ready),
+         .ddr_arid    (c_axi_ddr.ar_id),
+         .ddr_araddr  (c_axi_ddr.ar_addr),
+         .ddr_arlen   (c_axi_ddr.ar_len),
+         .ddr_arsize  (c_axi_ddr.ar_size),
+         .ddr_arburst (c_axi_ddr.ar_burst),
+         .ddr_arcache (c_axi_ddr.ar_cache),
+         .ddr_arprot  (c_axi_ddr.ar_prot),
+         .ddr_arqos   (c_axi_ddr.ar_qos),
+         .ddr_arvalid (c_axi_ddr.ar_valid),
+         .ddr_arready (c_axi_ddr.ar_ready),
+         .ddr_rid     (c_axi_ddr.r_id),
+         .ddr_rresp   (c_axi_ddr.r_resp),
+         .ddr_rdata   (c_axi_ddr.r_data),
+         .ddr_rlast   (c_axi_ddr.r_last),
+         .ddr_rvalid  (c_axi_ddr.r_valid),
+         .ddr_rready  (c_axi_ddr.r_ready)
+      );
+
+   // Memory interface: convert WishBone signals from system to AXI for DRAM
+   wb2axi
+     #(.ADDR_WIDTH (DDR_ADDR_WIDTH),
+       .DATA_WIDTH (DDR_DATA_WIDTH),
+       .AXI_ID_WIDTH (AXI_ID_WIDTH))
+   u_wb2axi_ddr
+     (.clk             (sys_clk),
+      .rst             (sys_rst),
+      .wb_cyc_i        (c_wb_ddr.cyc_o),
+      .wb_stb_i        (c_wb_ddr.stb_o),
+      .wb_we_i         (c_wb_ddr.we_o),
+      .wb_adr_i        (c_wb_ddr.adr_o),
+      .wb_dat_i        (c_wb_ddr.dat_o),
+      .wb_sel_i        (c_wb_ddr.sel_o),
+      .wb_cti_i        (c_wb_ddr.cti_o),
+      .wb_bte_i        (c_wb_ddr.bte_o),
+      .wb_ack_o        (c_wb_ddr.ack_i),
+      .wb_err_o        (c_wb_ddr.err_i),
+      .wb_rty_o        (c_wb_ddr.rty_i),
+      .wb_dat_o        (c_wb_ddr.dat_i),
+      .m_axi_awid      (c_axi_ddr.aw_id),
+      .m_axi_awaddr    (c_axi_ddr.aw_addr),
+      .m_axi_awlen     (c_axi_ddr.aw_len),
+      .m_axi_awsize    (c_axi_ddr.aw_size),
+      .m_axi_awburst   (c_axi_ddr.aw_burst),
+      .m_axi_awcache   (c_axi_ddr.aw_cache),
+      .m_axi_awprot    (c_axi_ddr.aw_prot),
+      .m_axi_awqos     (c_axi_ddr.aw_qos),
+      .m_axi_awvalid   (c_axi_ddr.aw_valid),
+      .m_axi_awready   (c_axi_ddr.aw_ready),
+      .m_axi_wdata     (c_axi_ddr.w_data),
+      .m_axi_wstrb     (c_axi_ddr.w_strb),
+      .m_axi_wlast     (c_axi_ddr.w_last),
+      .m_axi_wvalid    (c_axi_ddr.w_valid),
+      .m_axi_wready    (c_axi_ddr.w_ready),
+      .m_axi_bid       (c_axi_ddr.b_id),
+      .m_axi_bresp     (c_axi_ddr.b_resp),
+      .m_axi_bvalid    (c_axi_ddr.b_valid),
+      .m_axi_bready    (c_axi_ddr.b_ready),
+      .m_axi_arid      (c_axi_ddr.ar_id),
+      .m_axi_araddr    (c_axi_ddr.ar_addr),
+      .m_axi_arlen     (c_axi_ddr.ar_len),
+      .m_axi_arsize    (c_axi_ddr.ar_size),
+      .m_axi_arburst   (c_axi_ddr.ar_burst),
+      .m_axi_arcache   (c_axi_ddr.ar_cache),
+      .m_axi_arprot    (c_axi_ddr.ar_prot),
+      .m_axi_arqos     (c_axi_ddr.ar_qos),
+      .m_axi_arvalid   (c_axi_ddr.ar_valid),
+      .m_axi_arready   (c_axi_ddr.ar_ready),
+      .m_axi_rid       (c_axi_ddr.r_id),
+      .m_axi_rdata     (c_axi_ddr.r_data),
+      .m_axi_rresp     (c_axi_ddr.r_resp),
+      .m_axi_rlast     (c_axi_ddr.r_last),
+      .m_axi_rvalid    (c_axi_ddr.r_valid),
+      .m_axi_rready    (c_axi_ddr.r_ready)
+      );
+
+// tri-state assignment for mdio
+     wire eth_mdio_t;
+     wire eth_mdio_i;
+     wire eth_mdio_o;
+     //assign eth_mdio = eth_mdio_t ? eth_mdio_i : eth_mdio_o;
+     
+     IOBUF 
+        mdio_io_iobuf ( 
+           .I (eth_mdio_o ), 
+           .IO(eth_mdio   ), 
+           .O (eth_mdio_i ), 
+           .T (eth_mdio_t ));
+        
+     // PHY needs 50 Mhz clock shifted 45 deg compared to RMII 2 MII
+     // See Nexys 4 DDR board documentation for details.
+     assign eth_refclk = clk_50mhz_45deg;
+     
+     
+// AXI Ethernet Subsystem
+     
+     wire phy_rst_n;
+     assign eth_rstn = phy_rst_n;
+     
+     // wires MII2RMII Converter to Ethernet Subsystem
+        (* mark_debug = "true" *) wire [3:0] mii_txd;
+        (* mark_debug = "true" *) wire mii_tx_en;
+        (* mark_debug = "true" *) wire mii_tx_er;
+        (* mark_debug = "true" *) wire mii_tx_clk;
+        (* mark_debug = "true" *) wire mii_rx_clk;
+        (* mark_debug = "true" *) wire [3:0] mii_rxd;
+        (* mark_debug = "true" *) wire mii_rx_dv;
+        (* mark_debug = "true" *) wire mii_rx_er;
+                 
+     // wires AXI4Stream FIFO to Ethernet Subsystem
+        (* mark_debug = "true" *)   wire [31:0] s_axis_txc_tdata;
+        (* mark_debug = "true" *)   wire [3:0]  s_axis_txc_tkeep; // not in use
+        (* mark_debug = "true" *)   wire s_axis_txc_tlast;
+        (* mark_debug = "true" *)   wire s_axis_txc_tready;
+        (* mark_debug = "true" *)   wire s_axis_txc_tvalid;
+        
+        (* mark_debug = "true" *)   wire [31:0] s_axis_txd_tdata;
+        (* mark_debug = "true" *)   wire [3:0]  s_axis_txd_tkeep; // not in use
+        (* mark_debug = "true" *)   wire s_axis_txd_tlast;
+        (* mark_debug = "true" *)   wire s_axis_txd_tready;
+        (* mark_debug = "true" *)   wire s_axis_txd_tvalid;
+        
+        (* mark_debug = "true" *)   wire [31:0] m_axis_rxd_tdata;
+        (* mark_debug = "true" *)   wire [3:0]  m_axis_rxd_tkeep;
+        (* mark_debug = "true" *)   wire m_axis_rxd_tlast;
+        (* mark_debug = "true" *)   wire m_axis_rxd_tready;
+        (* mark_debug = "true" *)   wire m_axis_rxd_tvalid;         
+        
+
+       // wire AXI4 Ethernet Subsystem to WB2AXI Converter
+      //wire s_axi_aclk; // noch nicht verbunden!
+      //wire s_axi_aresetn;// noch nicht verbunden!
+        (* mark_debug = "true" *)wire [31:0] s_axi_awaddr;
+        (* mark_debug = "true" *)wire s_axi_awvalid;
+        (* mark_debug = "true" *)wire s_axi_awready;
+        (* mark_debug = "true" *)wire [31:0]s_axi_wdata;
+        (* mark_debug = "true" *)wire [3:0]s_axi_wstrb;
+        (* mark_debug = "true" *)wire s_axi_wvalid;
+        (* mark_debug = "true" *) wire s_axi_wready;
+        (* mark_debug = "true" *)wire [1:0]  s_axi_bresp;
+        (* mark_debug = "true" *)wire s_axi_bvalid;
+        (* mark_debug = "true" *)wire s_axi_bready;
+        (* mark_debug = "true" *)wire [31:0] s_axi_araddr;
+        (* mark_debug = "true" *)wire s_axi_arvalid;
+        (* mark_debug = "true" *)wire s_axi_arready;
+        (* mark_debug = "true" *)wire [31:0] s_axi_rdata;
+        (* mark_debug = "true" *)wire [1:0] s_axi_rresp;
+        (* mark_debug = "true" *)wire s_axi_rvalid;
+        (* mark_debug = "true" *)wire s_axi_rready;
+        (* mark_debug = "true" *)wire [3:0] s_axi_wstrb;
+                  
+   // wire AXI4 Stream FIFO to WB2AXI Converter
+   //wire fifo_s_axi_aclk; // noch nicht verbunden!
+   //wire fifo_s_axi_aresetn;// noch nicht verbunden!
+   (* mark_debug = "true" *)   wire [31:0] fifo_s_axi_awaddr;
+   (* mark_debug = "true" *)   wire fifo_s_axi_awvalid;
+   (* mark_debug = "true" *)   wire fifo_s_axi_awready;
+   (* mark_debug = "true" *)   wire [31:0] fifo_s_axi_wdata;
+   (* mark_debug = "true" *)   wire [3:0] fifo_s_axi_wstrb;
+   (* mark_debug = "true" *)   wire fifo_s_axi_wvalid;
+   (* mark_debug = "true" *)   wire fifo_s_axi_wready;
+   (* mark_debug = "true" *)   wire [1:0] fifo_s_axi_bresp;
+   (* mark_debug = "true" *)   wire fifo_s_axi_bvalid;
+   (* mark_debug = "true" *)   wire fifo_s_axi_bready;
+   (* mark_debug = "true" *)   wire [31:0] fifo_s_axi_araddr;
+   (* mark_debug = "true" *)    wire fifo_s_axi_arvalid;
+   (* mark_debug = "true" *)   wire fifo_s_axi_arready;
+   (* mark_debug = "true" *)   wire [31:0] fifo_s_axi_rdata;
+   (* mark_debug = "true" *)   wire [1:0] fifo_s_axi_rresp;
+   (* mark_debug = "true" *)   wire fifo_s_axi_rvalid;
+   (* mark_debug = "true" *)   wire fifo_s_axi_rready;       
+
+   // ASSUME THIS IS CORRECT!?
+   assign s_axis_txd_tkeep = 4'b1111;
+   assign s_axis_txc_tkeep = 4'b1111;
+   
+     axi_ethernet_0
+        u_axi_ethernet
+        (
+           // AXI Lite control interface
+           .s_axi_lite_clk      (sys_clk      ) ,
+           .s_axi_lite_resetn   (~sys_rst   ),
+           .s_axi_araddr        (s_axi_araddr      ),
+           .s_axi_arready       (s_axi_arready     ),
+           .s_axi_arvalid       (s_axi_arvalid     ),
+           .s_axi_awaddr        (s_axi_awaddr      ),
+           .s_axi_awready       (s_axi_awready     ),
+           .s_axi_awvalid       (s_axi_awvalid     ),
+           .s_axi_bready        (s_axi_bready      ),
+           .s_axi_bresp         (s_axi_bresp       ),
+           .s_axi_bvalid        (s_axi_bvalid      ),
+           .s_axi_rdata         (s_axi_rdata       ),
+           .s_axi_rready        (s_axi_rready      ),
+           .s_axi_rresp         (s_axi_rresp       ),
+           .s_axi_rvalid        (s_axi_rvalid      ),
+           .s_axi_wdata         (s_axi_wdata       ),
+           .s_axi_wready        (s_axi_wready      ),
+           .s_axi_wvalid        (s_axi_wvalid      ),
+           .s_axi_wstrb         (s_axi_wstrb       ),
+
+           // AXI Stream TX/RX interface
+           .axis_clk            (sys_clk          ),
+
+           .axi_txc_arstn       (~sys_rst         ),
+           .s_axis_txc_tdata    (s_axis_txc_tdata  ),
+           .s_axis_txc_tkeep    (s_axis_txc_tkeep  ),
+           .s_axis_txc_tlast    (s_axis_txc_tlast  ),
+           .s_axis_txc_tready   (s_axis_txc_tready ),
+           .s_axis_txc_tvalid   (s_axis_txc_tvalid ),
+
+           .axi_txd_arstn       (~sys_rst         ),
+           .s_axis_txd_tdata    (s_axis_txd_tdata  ),
+           .s_axis_txd_tkeep    (s_axis_txd_tkeep  ),
+           .s_axis_txd_tlast    (s_axis_txd_tlast  ),
+           .s_axis_txd_tready   (s_axis_txd_tready ),
+           .s_axis_txd_tvalid   (s_axis_txd_tvalid ),
+
+           .axi_rxd_arstn       (~sys_rst         ),
+           .m_axis_rxd_tdata    (m_axis_rxd_tdata  ),
+           .m_axis_rxd_tkeep    (m_axis_rxd_tkeep  ),
+           .m_axis_rxd_tlast    (m_axis_rxd_tlast  ),
+           .m_axis_rxd_tready   (m_axis_rxd_tready ),
+           .m_axis_rxd_tvalid   (m_axis_rxd_tvalid ),
+        
+           .axi_rxs_arstn       (~sys_rst         ), // not in use only for DMA
+           .m_axis_rxs_tdata    (  ), // not in use only for DMA
+           .m_axis_rxs_tkeep    (  ), // not in use only for DMA
+           .m_axis_rxs_tlast    (  ), // not in use only for DMA
+           .m_axis_rxs_tready   (1'b1 ), // not in use only for DMA
+           .m_axis_rxs_tvalid   ( ), // not in use only for DMA
+
+           // MII Interface
+           .mii_txd             (mii_txd           ),
+           .mii_tx_en           (mii_tx_en         ),
+           .mii_tx_er           (mii_tx_er         ),
+           .mii_tx_clk          (mii_tx_clk        ),
+           .mii_rx_clk          (mii_rx_clk        ),
+           .mii_rxd             (mii_rxd           ),
+           .mii_rx_dv           (mii_rx_dv         ),
+           .mii_rx_er           (mii_rx_er         ),
+
+           // Ethernet PHY connections
+           .mdio_mdc            (eth_mdc           ),
+           .mdio_mdio_i         (eth_mdio_i        ),
+           .mdio_mdio_o         (eth_mdio_o        ),
+           .mdio_mdio_t         (eth_mdio_t            ),
+           .phy_rst_n           (phy_rst_n         ), 
+
+           .gtx_clk             (clk_125mhz    )
+
+        );
+
+        
+        
+// MII to RMII Converter
+      mii_to_rmii_0
+         u_mii_to_rmii_0 
+         (
+              .ref_clk           (clk_50mhz),
+              .rst_n             (phy_rst_n),
+              .mac2rmii_tx_en    (mii_tx_en         ),
+              .mac2rmii_txd      (mii_txd           ),
+              .mac2rmii_tx_er    (mii_tx_er         ),
+              .rmii2mac_tx_clk   (mii_tx_clk        ),
+              .rmii2mac_rx_clk   (mii_rx_clk        ),
+              .rmii2mac_col      (),
+              .rmii2mac_crs      (led[0]), // debug only; carrier sense led
+              .rmii2mac_rx_dv    (mii_rx_dv         ),
+              .rmii2mac_rx_er    (mii_rx_er),
+              .rmii2mac_rxd      (mii_rxd           ),
+              .phy2rmii_crs_dv   (eth_crsdv),
+              .phy2rmii_rx_er    (eth_rxerr),
+              .phy2rmii_rxd      (eth_rxd  ),
+              .rmii2phy_txd      (eth_txd  ),
+              .rmii2phy_tx_en    (eth_txen )
+              
+           );
+// AXI4Stream FIFO
+      axi_fifo_mm_s_0
+         u_axi_fifo_mm_s_0
+         (
+            .s_axi_aclk            (sys_clk    ),
+            .s_axi_aresetn         (~sys_rst),
+            
+            .s_axi_awaddr          (fifo_s_axi_awaddr  ),
+            .s_axi_awvalid         (fifo_s_axi_awvalid ),
+            .s_axi_awready         (fifo_s_axi_awready ),
+            .s_axi_wdata           (fifo_s_axi_wdata   ),
+            .s_axi_wstrb           (fifo_s_axi_wstrb   ),
+            .s_axi_wvalid          (fifo_s_axi_wvalid  ),
+            .s_axi_wready          (fifo_s_axi_wready  ),
+            .s_axi_bresp           (fifo_s_axi_bresp   ),
+            .s_axi_bvalid          (fifo_s_axi_bvalid  ),
+            .s_axi_bready          (fifo_s_axi_bready  ),
+            .s_axi_araddr          (fifo_s_axi_araddr  ),
+            .s_axi_arvalid         (fifo_s_axi_arvalid ),
+            .s_axi_arready         (fifo_s_axi_arready ),
+            .s_axi_rdata           (fifo_s_axi_rdata   ),
+            .s_axi_rresp           (fifo_s_axi_rresp   ),
+            .s_axi_rvalid          (fifo_s_axi_rvalid  ),
+            .s_axi_rready          (fifo_s_axi_rready  ),
+            .mm2s_prmry_reset_out_n(),
+            .axi_str_txd_tvalid    (s_axis_txd_tvalid  ),
+            .axi_str_txd_tready    (s_axis_txd_tready  ),
+            .axi_str_txd_tlast     (s_axis_txd_tlast   ),
+            .axi_str_txd_tdata     (s_axis_txd_tdata   ),
+            .mm2s_cntrl_reset_out_n(),
+            .axi_str_txc_tvalid    (s_axis_txc_tvalid  ),
+            .axi_str_txc_tready    (s_axis_txc_tready  ),
+            .axi_str_txc_tlast     (s_axis_txc_tlast   ),
+            .axi_str_txc_tdata     (s_axis_txc_tdata   ),
+            .s2mm_prmry_reset_out_n(),
+            .axi_str_rxd_tvalid    (m_axis_rxd_tvalid  ),
+            .axi_str_rxd_tready    (m_axis_rxd_tready  ),
+            .axi_str_rxd_tlast     (m_axis_rxd_tlast   ),
+            .axi_str_rxd_tdata     (m_axis_rxd_tdata   ),
+            
+            .interrupt             (eth_irq)
+         );
+            
+         // Memory interface: convert WishBone signals from system to AXI for AXI4FIFO
+         wb2axi
+            #(.ADDR_WIDTH (32), // vielleich??
+               .DATA_WIDTH (32),// vielleich??
+               .AXI_ID_WIDTH (AXI_ID_WIDTH))// vielleich??
+            u_wb2axi_fifo
+            (.clk             (sys_clk),
+             .rst             (sys_rst),
+             .wb_cyc_i        (c_wb_fifo.cyc_o),
+             .wb_stb_i        (c_wb_fifo.stb_o),
+             .wb_we_i         (c_wb_fifo.we_o),
+             .wb_adr_i        (c_wb_fifo.adr_o),
+             .wb_dat_i        (c_wb_fifo.dat_o),
+             .wb_sel_i        (c_wb_fifo.sel_o),
+             .wb_cti_i        (c_wb_fifo.cti_o),
+             .wb_bte_i        (c_wb_fifo.bte_o),
+             .wb_ack_o        (c_wb_fifo.ack_i),
+             .wb_err_o        (c_wb_fifo.err_i),
+             .wb_rty_o        (c_wb_fifo.rty_i),
+             .wb_dat_o        (c_wb_fifo.dat_i),
+             .m_axi_awid      (),
+             .m_axi_awaddr    (fifo_s_axi_awaddr),
+             .m_axi_awlen     (),
+             .m_axi_awsize    (),
+             .m_axi_awburst   (),
+             .m_axi_awcache   (),
+             .m_axi_awprot    (),
+             .m_axi_awqos     (),
+             .m_axi_awvalid   (fifo_s_axi_awvalid),
+             .m_axi_awready   (fifo_s_axi_awready),
+             .m_axi_wdata     (fifo_s_axi_wdata),
+             .m_axi_wstrb     (fifo_s_axi_wstrb),
+             .m_axi_wlast     (),
+             .m_axi_wvalid    (fifo_s_axi_wvalid),
+             .m_axi_wready    (fifo_s_axi_wready),
+             .m_axi_bid       (),
+             .m_axi_bresp     (fifo_s_axi_bresp),
+             .m_axi_bvalid    (fifo_s_axi_bvalid),
+             .m_axi_bready    (fifo_s_axi_bready),
+             .m_axi_arid      (),
+             .m_axi_araddr    (fifo_s_axi_araddr),
+             .m_axi_arlen     (),
+             .m_axi_arsize    (),
+             .m_axi_arburst   (),
+             .m_axi_arcache   (),
+             .m_axi_arprot    (),
+             .m_axi_arqos     (),
+             .m_axi_arvalid   (fifo_s_axi_arvalid),
+             .m_axi_arready   (fifo_s_axi_arready),
+             .m_axi_rid       (),
+             .m_axi_rdata     (fifo_s_axi_rdata),
+             .m_axi_rresp     (fifo_s_axi_rresp),
+             .m_axi_rlast     (),
+             .m_axi_rvalid    (fifo_s_axi_rvalid),
+             .m_axi_rready    (fifo_s_axi_rready)
+            );
+
+            
+// Memory interface: convert WishBone signals from system to AXI for AXI Ethernet Subsystem
+            wb2axi
+               #(.ADDR_WIDTH (32), // vielleich??
+                  .DATA_WIDTH (32),// vielleich??
+                  .AXI_ID_WIDTH (AXI_ID_WIDTH))// vielleich??
+               u_wb2axi_ess
+               (.clk             (sys_clk),
+                  .rst             (sys_rst),
+                  .wb_cyc_i        (c_wb_ess.cyc_o),
+                  .wb_stb_i        (c_wb_ess.stb_o),
+                  .wb_we_i         (c_wb_ess.we_o),
+                  .wb_adr_i        (c_wb_ess.adr_o),
+                  .wb_dat_i        (c_wb_ess.dat_o),
+                  .wb_sel_i        (c_wb_ess.sel_o),
+                  .wb_cti_i        (c_wb_ess.cti_o),
+                  .wb_bte_i        (c_wb_ess.bte_o),
+                  .wb_ack_o        (c_wb_ess.ack_i),
+                  .wb_err_o        (c_wb_ess.err_i),
+                  .wb_rty_o        (c_wb_ess.rty_i),
+                  .wb_dat_o        (c_wb_ess.dat_i),
+                  .m_axi_awid      (),
+                  .m_axi_awaddr    (s_axi_awaddr),
+                  .m_axi_awlen     (),
+                  .m_axi_awsize    (),
+                  .m_axi_awburst   (),
+                  .m_axi_awcache   (),
+                  .m_axi_awprot    (),
+                  .m_axi_awqos     (),
+                  .m_axi_awvalid   (s_axi_awvalid),
+                  .m_axi_awready   (s_axi_awready),
+                  .m_axi_wdata     (s_axi_wdata),
+                  .m_axi_wstrb     (s_axi_wstrb),
+                  .m_axi_wlast     (),
+                  .m_axi_wvalid    (s_axi_wvalid),
+                  .m_axi_wready    (s_axi_wready),
+                  .m_axi_bid       (),
+                  .m_axi_bresp     (s_axi_bresp),
+                  .m_axi_bvalid    (s_axi_bvalid),
+                  .m_axi_bready    (s_axi_bready),
+                  .m_axi_arid      (),
+                  .m_axi_araddr    (s_axi_araddr),
+                  .m_axi_arlen     (),
+                  .m_axi_arsize    (),
+                  .m_axi_arburst   (),
+                  .m_axi_arcache   (),
+                  .m_axi_arprot    (),
+                  .m_axi_arqos     (),
+                  .m_axi_arvalid   (s_axi_arvalid),
+                  .m_axi_arready   (s_axi_arready),
+                  .m_axi_rid       (),
+                  .m_axi_rdata     (s_axi_rdata),
+                  .m_axi_rresp     (s_axi_rresp),
+                  .m_axi_rlast     (),
+                  .m_axi_rvalid    (s_axi_rvalid),
+                  .m_axi_rready    (s_axi_rready)
+               );            
+     
+     
+endmodule

--- a/external/extra_cores/boards/nexys4ddr/data/pins.xdc
+++ b/external/extra_cores/boards/nexys4ddr/data/pins.xdc
@@ -6,44 +6,87 @@
 ## https://reference.digilentinc.com/_media/nexys4-ddr:nexys4ddr_rm.pdf
 
 ## 100 MHz Clock signal
-set_property -dict {PACKAGE_PIN E3 IOSTANDARD LVCMOS33} [get_ports -quiet clk]
-create_clock -period 10.000 -name sys_clk_pin -waveform {0.000 5.000} -add [get_ports -quiet clk]
+set_property -quiet -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports -quiet { clk }]; #IO_L12P_T1_MRCC_35 Sch=clk100mhz
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports -quiet {clk}];
 
 
 ## Switches
 
+set_property -quiet -dict { PACKAGE_PIN J15   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[0] }]; #IO_L24N_T3_RS0_15 Sch=sw[0]
+set_property -quiet -dict { PACKAGE_PIN L16   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[1] }]; #IO_L3N_T0_DQS_EMCCLK_14 Sch=sw[1]
+set_property -quiet -dict { PACKAGE_PIN M13   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[2] }]; #IO_L6N_T0_D08_VREF_14 Sch=sw[2]
+set_property -quiet -dict { PACKAGE_PIN R15   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[3] }]; #IO_L13N_T2_MRCC_14 Sch=sw[3]
+set_property -quiet -dict { PACKAGE_PIN R17   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[4] }]; #IO_L12N_T1_MRCC_14 Sch=sw[4]
+set_property -quiet -dict { PACKAGE_PIN T18   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[5] }]; #IO_L7N_T1_D10_14 Sch=sw[5]
+set_property -quiet -dict { PACKAGE_PIN U18   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[6] }]; #IO_L17N_T2_A13_D29_14 Sch=sw[6]
+set_property -quiet -dict { PACKAGE_PIN R13   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[7] }]; #IO_L5N_T0_D07_14 Sch=sw[7]
+set_property -quiet -dict { PACKAGE_PIN T8    IOSTANDARD LVCMOS18 } [get_ports -quiet { sw[8] }]; #IO_L24N_T3_34 Sch=sw[8]
+set_property -quiet -dict { PACKAGE_PIN U8    IOSTANDARD LVCMOS18 } [get_ports -quiet { sw[9] }]; #IO_25_34 Sch=sw[9]
+set_property -quiet -dict { PACKAGE_PIN R16   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[10] }]; #IO_L15P_T2_DQS_RDWR_B_14 Sch=sw[10]
+set_property -quiet -dict { PACKAGE_PIN T13   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[11] }]; #IO_L23P_T3_A03_D19_14 Sch=sw[11]
+set_property -quiet -dict { PACKAGE_PIN H6    IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[12] }]; #IO_L24P_T3_35 Sch=sw[12]
+set_property -quiet -dict { PACKAGE_PIN U12   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[13] }]; #IO_L20P_T3_A08_D24_14 Sch=sw[13]
+set_property -quiet -dict { PACKAGE_PIN U11   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[14] }]; #IO_L19N_T3_A09_D25_VREF_14 Sch=sw[14]
+set_property -quiet -dict { PACKAGE_PIN V10   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[15] }]; #IO_L21P_T3_DQS_14 Sch=sw[15]
 
 
 ## LEDs
 
-set_property -dict {PACKAGE_PIN H17 IOSTANDARD LVCMOS33} [get_ports -quiet {led[0]}]
-set_property -dict {PACKAGE_PIN K15 IOSTANDARD LVCMOS33} [get_ports -quiet {led[1]}]
-set_property -dict {PACKAGE_PIN J13 IOSTANDARD LVCMOS33} [get_ports -quiet {led[2]}]
-set_property -dict {PACKAGE_PIN N14 IOSTANDARD LVCMOS33} [get_ports -quiet {led[3]}]
-set_property -dict {PACKAGE_PIN R18 IOSTANDARD LVCMOS33} [get_ports -quiet {led[4]}]
-set_property -dict {PACKAGE_PIN V17 IOSTANDARD LVCMOS33} [get_ports -quiet {led[5]}]
-set_property -dict {PACKAGE_PIN U17 IOSTANDARD LVCMOS33} [get_ports -quiet {led[6]}]
-set_property -dict {PACKAGE_PIN U16 IOSTANDARD LVCMOS33} [get_ports -quiet {led[7]}]
-set_property -dict {PACKAGE_PIN V16 IOSTANDARD LVCMOS33} [get_ports -quiet {led[8]}]
-set_property -dict {PACKAGE_PIN T15 IOSTANDARD LVCMOS33} [get_ports -quiet {led[9]}]
-set_property -dict {PACKAGE_PIN U14 IOSTANDARD LVCMOS33} [get_ports -quiet {led[10]}]
-set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS33} [get_ports -quiet {led[11]}]
-set_property -dict {PACKAGE_PIN V15 IOSTANDARD LVCMOS33} [get_ports -quiet {led[12]}]
-set_property -dict {PACKAGE_PIN V14 IOSTANDARD LVCMOS33} [get_ports -quiet {led[13]}]
-set_property -dict {PACKAGE_PIN V12 IOSTANDARD LVCMOS33} [get_ports -quiet {led[14]}]
-set_property -dict {PACKAGE_PIN V11 IOSTANDARD LVCMOS33} [get_ports -quiet {led[15]}]
+set_property -quiet -dict { PACKAGE_PIN H17   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[0] }]; #IO_L18P_T2_A24_15 Sch=led[0]
+set_property -quiet -dict { PACKAGE_PIN K15   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[1] }]; #IO_L24P_T3_RS1_15 Sch=led[1]
+set_property -quiet -dict { PACKAGE_PIN J13   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[2] }]; #IO_L17N_T2_A25_15 Sch=led[2]
+set_property -quiet -dict { PACKAGE_PIN N14   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[3] }]; #IO_L8P_T1_D11_14 Sch=led[3]
+set_property -quiet -dict { PACKAGE_PIN R18   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[4] }]; #IO_L7P_T1_D09_14 Sch=led[4]
+set_property -quiet -dict { PACKAGE_PIN V17   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[5] }]; #IO_L18N_T2_A11_D27_14 Sch=led[5]
+set_property -quiet -dict { PACKAGE_PIN U17   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[6] }]; #IO_L17P_T2_A14_D30_14 Sch=led[6]
+set_property -quiet -dict { PACKAGE_PIN U16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[7] }]; #IO_L18P_T2_A12_D28_14 Sch=led[7]
+set_property -quiet -dict { PACKAGE_PIN V16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[8] }]; #IO_L16N_T2_A15_D31_14 Sch=led[8]
+set_property -quiet -dict { PACKAGE_PIN T15   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[9] }]; #IO_L14N_T2_SRCC_14 Sch=led[9]
+set_property -quiet -dict { PACKAGE_PIN U14   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[10] }]; #IO_L22P_T3_A05_D21_14 Sch=led[10]
+set_property -quiet -dict { PACKAGE_PIN T16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[11] }]; #IO_L15N_T2_DQS_DOUT_CSO_B_14 Sch=led[11]
+set_property -quiet -dict { PACKAGE_PIN V15   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[12] }]; #IO_L16P_T2_CSI_B_14 Sch=led[12]
+set_property -quiet -dict { PACKAGE_PIN V14   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[13] }]; #IO_L22N_T3_A04_D20_14 Sch=led[13]
+set_property -quiet -dict { PACKAGE_PIN V12   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[14] }]; #IO_L20N_T3_A07_D23_14 Sch=led[14]
+set_property -quiet -dict { PACKAGE_PIN V11   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[15] }]; #IO_L21N_T3_DQS_A06_D22_14 Sch=led[15]
 
+set_property -quiet -dict { PACKAGE_PIN R12   IOSTANDARD LVCMOS33 } [get_ports -quiet { led16_b }]; #IO_L5P_T0_D06_14 Sch=led16_b
+set_property -quiet -dict { PACKAGE_PIN M16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led16_g }]; #IO_L10P_T1_D14_14 Sch=led16_g
+set_property -quiet -dict { PACKAGE_PIN N15   IOSTANDARD LVCMOS33 } [get_ports -quiet { led16_r }]; #IO_L11P_T1_SRCC_14 Sch=led16_r
+set_property -quiet -dict { PACKAGE_PIN G14   IOSTANDARD LVCMOS33 } [get_ports -quiet { led17_b }]; #IO_L15N_T2_DQS_ADV_B_15 Sch=led17_b
+set_property -quiet -dict { PACKAGE_PIN R11   IOSTANDARD LVCMOS33 } [get_ports -quiet { led17_g }]; #IO_0_14 Sch=led17_g
+set_property -quiet -dict { PACKAGE_PIN N16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led17_r }]; #IO_L11N_T1_SRCC_14 Sch=led17_r
 
 
 ## 7 segment display
 
+set_property -quiet -dict { PACKAGE_PIN T10   IOSTANDARD LVCMOS33 } [get_ports -quiet { ca }]; #IO_L24N_T3_A00_D16_14 Sch=ca
+set_property -quiet -dict { PACKAGE_PIN R10   IOSTANDARD LVCMOS33 } [get_ports -quiet { cb }]; #IO_25_14 Sch=cb
+set_property -quiet -dict { PACKAGE_PIN K16   IOSTANDARD LVCMOS33 } [get_ports -quiet { cc }]; #IO_25_15 Sch=cc
+set_property -quiet -dict { PACKAGE_PIN K13   IOSTANDARD LVCMOS33 } [get_ports -quiet { cd }]; #IO_L17P_T2_A26_15 Sch=cd
+set_property -quiet -dict { PACKAGE_PIN P15   IOSTANDARD LVCMOS33 } [get_ports -quiet { ce }]; #IO_L13P_T2_MRCC_14 Sch=ce
+set_property -quiet -dict { PACKAGE_PIN T11   IOSTANDARD LVCMOS33 } [get_ports -quiet { cf }]; #IO_L19P_T3_A10_D26_14 Sch=cf
+set_property -quiet -dict { PACKAGE_PIN L18   IOSTANDARD LVCMOS33 } [get_ports -quiet { cg }]; #IO_L4P_T0_D04_14 Sch=cg
 
+set_property -quiet -dict { PACKAGE_PIN H15   IOSTANDARD LVCMOS33 } [get_ports -quiet { dp }]; #IO_L19N_T3_A21_VREF_15 Sch=dp
 
+set_property -quiet -dict { PACKAGE_PIN J17   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[0] }]; #IO_L23P_T3_FOE_B_15 Sch=an[0]
+set_property -quiet -dict { PACKAGE_PIN J18   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[1] }]; #IO_L23N_T3_FWE_B_15 Sch=an[1]
+set_property -quiet -dict { PACKAGE_PIN T9    IOSTANDARD LVCMOS33 } [get_ports -quiet { an[2] }]; #IO_L24P_T3_A01_D17_14 Sch=an[2]
+set_property -quiet -dict { PACKAGE_PIN J14   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[3] }]; #IO_L19P_T3_A22_15 Sch=an[3]
+set_property -quiet -dict { PACKAGE_PIN P14   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[4] }]; #IO_L8N_T1_D12_14 Sch=an[4]
+set_property -quiet -dict { PACKAGE_PIN T14   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[5] }]; #IO_L14P_T2_SRCC_14 Sch=an[5]
+set_property -quiet -dict { PACKAGE_PIN K2    IOSTANDARD LVCMOS33 } [get_ports -quiet { an[6] }]; #IO_L23P_T3_35 Sch=an[6]
+set_property -quiet -dict { PACKAGE_PIN U13   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[7] }]; #IO_L23N_T3_A02_D18_14 Sch=an[7]
 
 ## Buttons
 
-set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS33} [get_ports -quiet cpu_resetn]
+set_property -quiet -dict { PACKAGE_PIN C12   IOSTANDARD LVCMOS33 } [get_ports -quiet { cpu_resetn }]; #IO_L3P_T0_DQS_AD1P_15 Sch=cpu_resetn
 
+set_property -quiet -dict { PACKAGE_PIN N17   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnc }]; #IO_L9P_T1_DQS_14 Sch=btnc
+set_property -quiet -dict { PACKAGE_PIN M18   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnu }]; #IO_L4N_T0_D05_14 Sch=btnu
+set_property -quiet -dict { PACKAGE_PIN P17   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnl }]; #IO_L12P_T1_MRCC_14 Sch=btnl
+set_property -quiet -dict { PACKAGE_PIN M17   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnr }]; #IO_L10N_T1_D15_14 Sch=btnr
+set_property -quiet -dict { PACKAGE_PIN P18   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnd }]; #IO_L9N_T1_DQS_D13_14 Sch=btnd
 
 
 ## Pmod Headers
@@ -51,22 +94,62 @@ set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS33} [get_ports -quiet cpu_r
 
 ## Pmod Header JA
 
+set_property -quiet -dict { PACKAGE_PIN C17   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[0] }]; #IO_L20N_T3_A19_15 Sch=ja[1]
+set_property -quiet -dict { PACKAGE_PIN D18   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[1] }]; #IO_L21N_T3_DQS_A18_15 Sch=ja[2]
+set_property -quiet -dict { PACKAGE_PIN E18   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[2] }]; #IO_L21P_T3_DQS_15 Sch=ja[3]
+set_property -quiet -dict { PACKAGE_PIN G17   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[3] }]; #IO_L18N_T2_A23_15 Sch=ja[4]
+set_property -quiet -dict { PACKAGE_PIN D17   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[4] }]; #IO_L16N_T2_A27_15 Sch=ja[7]
+set_property -quiet -dict { PACKAGE_PIN E17   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[5] }]; #IO_L16P_T2_A28_15 Sch=ja[8]
+set_property -quiet -dict { PACKAGE_PIN F18   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[6] }]; #IO_L22N_T3_A16_15 Sch=ja[9]
+set_property -quiet -dict { PACKAGE_PIN G18   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[7] }]; #IO_L22P_T3_A17_15 Sch=ja[10]
 
 
 ## Pmod Header JB
 
+set_property -quiet -dict { PACKAGE_PIN D14   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[0] }]; #IO_L1P_T0_AD0P_15 Sch=jb[1]
+set_property -quiet -dict { PACKAGE_PIN F16   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[1] }]; #IO_L14N_T2_SRCC_15 Sch=jb[2]
+set_property -quiet -dict { PACKAGE_PIN G16   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[2] }]; #IO_L13N_T2_MRCC_15 Sch=jb[3]
+set_property -quiet -dict { PACKAGE_PIN H14   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[3] }]; #IO_L15P_T2_DQS_15 Sch=jb[4]
+set_property -quiet -dict { PACKAGE_PIN E16   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[4] }]; #IO_L11N_T1_SRCC_15 Sch=jb[7]
+set_property -quiet -dict { PACKAGE_PIN F13   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[5] }]; #IO_L5P_T0_AD9P_15 Sch=jb[8]
+set_property -quiet -dict { PACKAGE_PIN G13   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[6] }]; #IO_0_15 Sch=jb[9]
+set_property -quiet -dict { PACKAGE_PIN H16   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[7] }]; #IO_L13P_T2_MRCC_15 Sch=jb[10]
 
 
 ## Pmod Header JC
 
+set_property -quiet -dict { PACKAGE_PIN K1    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[0] }]; #IO_L23N_T3_35 Sch=jc[1]
+set_property -quiet -dict { PACKAGE_PIN F6    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[1] }]; #IO_L19N_T3_VREF_35 Sch=jc[2]
+set_property -quiet -dict { PACKAGE_PIN J2    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[2] }]; #IO_L22N_T3_35 Sch=jc[3]
+set_property -quiet -dict { PACKAGE_PIN G6    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[3] }]; #IO_L19P_T3_35 Sch=jc[4]
+set_property -quiet -dict { PACKAGE_PIN E7    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[4] }]; #IO_L6P_T0_35 Sch=jc[7]
+set_property -quiet -dict { PACKAGE_PIN J3    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[5] }]; #IO_L22P_T3_35 Sch=jc[8]
+set_property -quiet -dict { PACKAGE_PIN J4    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[6] }]; #IO_L21P_T3_DQS_35 Sch=jc[9]
+set_property -quiet -dict { PACKAGE_PIN E6    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[7] }]; #IO_L5P_T0_AD13P_35 Sch=jc[10]
 
 
 ## Pmod Header JD
 
+set_property -quiet -dict { PACKAGE_PIN H4    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[0] }]; #IO_L21N_T3_DQS_35 Sch=jd[1]
+set_property -quiet -dict { PACKAGE_PIN H1    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[1] }]; #IO_L17P_T2_35 Sch=jd[2]
+set_property -quiet -dict { PACKAGE_PIN G1    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[2] }]; #IO_L17N_T2_35 Sch=jd[3]
+set_property -quiet -dict { PACKAGE_PIN G3    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[3] }]; #IO_L20N_T3_35 Sch=jd[4]
+set_property -quiet -dict { PACKAGE_PIN H2    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[4] }]; #IO_L15P_T2_DQS_35 Sch=jd[7]
+set_property -quiet -dict { PACKAGE_PIN G4    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[5] }]; #IO_L20P_T3_35 Sch=jd[8]
+set_property -quiet -dict { PACKAGE_PIN G2    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[6] }]; #IO_L15N_T2_DQS_35 Sch=jd[9]
+set_property -quiet -dict { PACKAGE_PIN F3    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[7] }]; #IO_L13N_T2_MRCC_35 Sch=jd[10]
 
 
 ## Pmod Header JXADC
 
+set_property -quiet -dict { PACKAGE_PIN A14   IOSTANDARD LVDS     } [get_ports -quiet { xa_n[0] }]; #IO_L9N_T1_DQS_AD3N_15 Sch=xa_n[1]
+set_property -quiet -dict { PACKAGE_PIN A13   IOSTANDARD LVDS     } [get_ports -quiet { xa_p[0] }]; #IO_L9P_T1_DQS_AD3P_15 Sch=xa_p[1]
+set_property -quiet -dict { PACKAGE_PIN A16   IOSTANDARD LVDS     } [get_ports -quiet { xa_n[1] }]; #IO_L8N_T1_AD10N_15 Sch=xa_n[2]
+set_property -quiet -dict { PACKAGE_PIN A15   IOSTANDARD LVDS     } [get_ports -quiet { xa_p[1] }]; #IO_L8P_T1_AD10P_15 Sch=xa_p[2]
+set_property -quiet -dict { PACKAGE_PIN B17   IOSTANDARD LVDS     } [get_ports -quiet { xa_n[2] }]; #IO_L7N_T1_AD2N_15 Sch=xa_n[3]
+set_property -quiet -dict { PACKAGE_PIN B16   IOSTANDARD LVDS     } [get_ports -quiet { xa_p[2] }]; #IO_L7P_T1_AD2P_15 Sch=xa_p[3]
+set_property -quiet -dict { PACKAGE_PIN A18   IOSTANDARD LVDS     } [get_ports -quiet { xa_n[3] }]; #IO_L10N_T1_AD11N_15 Sch=xa_n[4]
+set_property -quiet -dict { PACKAGE_PIN B18   IOSTANDARD LVDS     } [get_ports -quiet { xa_p[3] }]; #IO_L10P_T1_AD11P_15 Sch=xa_p[4]
 
 
 ## VGA Connector
@@ -135,12 +218,12 @@ set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS33} [get_ports -quiet cpu_r
 ## USB-RS232 Interface
 ## From FT2232H: http://www.ftdichip.com/Support/Documents/DataSheets/ICs/DS_FT2232H.pdf
 ## We left the pin names as they are used by Digilent, even though they are confusing for CTS/RTS
-set_property -dict {PACKAGE_PIN C4 IOSTANDARD LVCMOS33} [get_ports -quiet uart_txd_in]
-set_property -dict {PACKAGE_PIN D4 IOSTANDARD LVCMOS33} [get_ports -quiet uart_rxd_out]
+set_property -quiet -dict { PACKAGE_PIN C4    IOSTANDARD LVCMOS33 } [get_ports -quiet { uart_txd_in }]; #IO_L7P_T1_AD6P_35 Sch=uart_txd_in
+set_property -quiet -dict { PACKAGE_PIN D4    IOSTANDARD LVCMOS33 } [get_ports -quiet { uart_rxd_out }]; #IO_L11N_T1_SRCC_35 Sch=uart_rxd_out
 # CTS from the PC (output on the FPGA); active low (despite the name)
-set_property -dict {PACKAGE_PIN D3 IOSTANDARD LVCMOS33} [get_ports -quiet uart_cts]
+set_property -quiet -dict { PACKAGE_PIN D3    IOSTANDARD LVCMOS33 } [get_ports -quiet { uart_cts }]; #IO_L12N_T1_MRCC_35 Sch=uart_cts
 # RTS from the PC (input on the FPGA); active low (despite the name)
-set_property -dict {PACKAGE_PIN E5 IOSTANDARD LVCMOS33} [get_ports -quiet uart_rts]
+set_property -quiet -dict { PACKAGE_PIN E5    IOSTANDARD LVCMOS33 } [get_ports -quiet { uart_rts }]; #IO_L5N_T0_AD13N_35 Sch=uart_rts
 
 ## USB HID (PS/2)
 
@@ -150,17 +233,18 @@ set_property -dict {PACKAGE_PIN E5 IOSTANDARD LVCMOS33} [get_ports -quiet uart_r
 
 ## SMSC Ethernet PHY
 
-set_property -dict {PACKAGE_PIN C9 IOSTANDARD LVCMOS33} [get_ports -quiet eth_mdc]
-set_property -dict {PACKAGE_PIN A9 IOSTANDARD LVCMOS33} [get_ports -quiet eth_mdio]
-set_property -dict {PACKAGE_PIN B3 IOSTANDARD LVCMOS33} [get_ports -quiet eth_rstn]
-set_property -dict {PACKAGE_PIN D9 IOSTANDARD LVCMOS33} [get_ports -quiet eth_crsdv]
-set_property -dict {PACKAGE_PIN C10 IOSTANDARD LVCMOS33} [get_ports -quiet eth_rxerr]
-set_property -dict {PACKAGE_PIN C11 IOSTANDARD LVCMOS33} [get_ports -quiet {eth_rxd[0]}]
-set_property -dict {PACKAGE_PIN D10 IOSTANDARD LVCMOS33} [get_ports -quiet {eth_rxd[1]}]
-set_property -dict {PACKAGE_PIN B9 IOSTANDARD LVCMOS33} [get_ports -quiet eth_txen]
-set_property -dict {PACKAGE_PIN A10 IOSTANDARD LVCMOS33} [get_ports -quiet {eth_txd[0]}]
-set_property -dict {PACKAGE_PIN A8 IOSTANDARD LVCMOS33} [get_ports -quiet {eth_txd[1]}]
-set_property -dict {PACKAGE_PIN D5 IOSTANDARD LVCMOS33} [get_ports -quiet eth_refclk]
+set_property -quiet -dict { PACKAGE_PIN C9    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_mdc }]; #IO_L11P_T1_SRCC_16 Sch=eth_mdc
+set_property -quiet -dict { PACKAGE_PIN A9    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_mdio }]; #IO_L14N_T2_SRCC_16 Sch=eth_mdio
+set_property -quiet -dict { PACKAGE_PIN B3    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_rstn }]; #IO_L10P_T1_AD15P_35 Sch=eth_rstn
+set_property -quiet -dict { PACKAGE_PIN D9    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_crsdv }]; #IO_L6N_T0_VREF_16 Sch=eth_crsdv
+set_property -quiet -dict { PACKAGE_PIN C10   IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_rxerr }]; #IO_L13N_T2_MRCC_16 Sch=eth_rxerr
+set_property -quiet -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_rxd[0] }]; #IO_L13P_T2_MRCC_16 Sch=eth_rxd[0]
+set_property -quiet -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_rxd[1] }]; #IO_L19N_T3_VREF_16 Sch=eth_rxd[1]
+set_property -quiet -dict { PACKAGE_PIN B9    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_txen }]; #IO_L11N_T1_SRCC_16 Sch=eth_txen
+set_property -quiet -dict { PACKAGE_PIN A10   IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_txd[0] }]; #IO_L14P_T2_SRCC_16 Sch=eth_txd[0]
+set_property -quiet -dict { PACKAGE_PIN A8    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_txd[1] }]; #IO_L12N_T1_MRCC_16 Sch=eth_txd[1]
+set_property -quiet -dict { PACKAGE_PIN D5    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_refclk }]; #IO_L11P_T1_SRCC_35 Sch=eth_refclk
+set_property -quiet -dict { PACKAGE_PIN B8    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_intn }]; #IO_L12P_T1_MRCC_16 Sch=eth_intn
 
 
 ## Quad SPI Flash
@@ -170,296 +254,3 @@ set_property -dict {PACKAGE_PIN D5 IOSTANDARD LVCMOS33} [get_ports -quiet eth_re
 #set_property -quiet -dict { PACKAGE_PIN L14   IOSTANDARD LVCMOS33 } [get_ports -quiet { qspi_dq[2] }]; #IO_L2P_T0_D02_14 Sch=qspi_dq[2]
 #set_property -quiet -dict { PACKAGE_PIN M14   IOSTANDARD LVCMOS33 } [get_ports -quiet { qspi_dq[3] }]; #IO_L2N_T0_D03_14 Sch=qspi_dq[3]
 #set_property -quiet -dict { PACKAGE_PIN L13   IOSTANDARD LVCMOS33 } [get_ports -quiet { qspi_csn }]; #IO_L6P_T0_FCS_B_14 Sch=qspi_csn
-
-
-
-
-
-
-connect_debug_port u_ila_0/probe0 [get_nets [list {s_axis_txd_tkeep[0]} {s_axis_txd_tkeep[1]} {s_axis_txd_tkeep[2]} {s_axis_txd_tkeep[3]}]]
-connect_debug_port u_ila_0/probe2 [get_nets [list {s_axis_txc_tkeep[0]} {s_axis_txc_tkeep[1]} {s_axis_txc_tkeep[2]} {s_axis_txc_tkeep[3]}]]
-connect_debug_port u_ila_0/probe4 [get_nets [list {s_axi_wstrb[0]} {s_axi_wstrb[1]} {s_axi_wstrb[2]} {s_axi_wstrb[3]}]]
-connect_debug_port u_ila_0/probe5 [get_nets [list {s_axi_wdata[0]} {s_axi_wdata[1]} {s_axi_wdata[2]} {s_axi_wdata[3]} {s_axi_wdata[4]} {s_axi_wdata[5]} {s_axi_wdata[6]} {s_axi_wdata[7]} {s_axi_wdata[8]} {s_axi_wdata[9]} {s_axi_wdata[10]} {s_axi_wdata[11]} {s_axi_wdata[12]} {s_axi_wdata[13]} {s_axi_wdata[14]} {s_axi_wdata[15]} {s_axi_wdata[16]} {s_axi_wdata[17]} {s_axi_wdata[18]} {s_axi_wdata[19]} {s_axi_wdata[20]} {s_axi_wdata[21]} {s_axi_wdata[22]} {s_axi_wdata[23]} {s_axi_wdata[24]} {s_axi_wdata[25]} {s_axi_wdata[26]} {s_axi_wdata[27]} {s_axi_wdata[28]} {s_axi_wdata[29]} {s_axi_wdata[30]} {s_axi_wdata[31]}]]
-connect_debug_port u_ila_0/probe9 [get_nets [list {s_axi_awaddr[0]} {s_axi_awaddr[1]} {s_axi_awaddr[2]} {s_axi_awaddr[3]} {s_axi_awaddr[4]} {s_axi_awaddr[5]} {s_axi_awaddr[6]} {s_axi_awaddr[7]} {s_axi_awaddr[8]} {s_axi_awaddr[9]} {s_axi_awaddr[10]} {s_axi_awaddr[11]} {s_axi_awaddr[12]} {s_axi_awaddr[13]} {s_axi_awaddr[14]} {s_axi_awaddr[15]} {s_axi_awaddr[16]} {s_axi_awaddr[17]} {s_axi_awaddr[18]} {s_axi_awaddr[19]} {s_axi_awaddr[20]} {s_axi_awaddr[21]} {s_axi_awaddr[22]} {s_axi_awaddr[23]} {s_axi_awaddr[24]} {s_axi_awaddr[25]} {s_axi_awaddr[26]} {s_axi_awaddr[27]} {s_axi_awaddr[28]} {s_axi_awaddr[29]} {s_axi_awaddr[30]} {s_axi_awaddr[31]}]]
-connect_debug_port u_ila_0/probe10 [get_nets [list {s_axi_araddr[0]} {s_axi_araddr[1]} {s_axi_araddr[2]} {s_axi_araddr[3]} {s_axi_araddr[4]} {s_axi_araddr[5]} {s_axi_araddr[6]} {s_axi_araddr[7]} {s_axi_araddr[8]} {s_axi_araddr[9]} {s_axi_araddr[10]} {s_axi_araddr[11]} {s_axi_araddr[12]} {s_axi_araddr[13]} {s_axi_araddr[14]} {s_axi_araddr[15]} {s_axi_araddr[16]} {s_axi_araddr[17]} {s_axi_araddr[18]} {s_axi_araddr[19]} {s_axi_araddr[20]} {s_axi_araddr[21]} {s_axi_araddr[22]} {s_axi_araddr[23]} {s_axi_araddr[24]} {s_axi_araddr[25]} {s_axi_araddr[26]} {s_axi_araddr[27]} {s_axi_araddr[28]} {s_axi_araddr[29]} {s_axi_araddr[30]} {s_axi_araddr[31]}]]
-connect_debug_port u_ila_0/probe11 [get_nets [list {m_axis_rxd_tkeep[0]} {m_axis_rxd_tkeep[1]} {m_axis_rxd_tkeep[2]} {m_axis_rxd_tkeep[3]}]]
-connect_debug_port u_ila_0/probe28 [get_nets [list s_axi_bready]]
-connect_debug_port u_ila_0/probe30 [get_nets [list s_axi_rready]]
-
-
-
-
-create_debug_core u_ila_0 ila
-set_property ALL_PROBE_SAME_MU true [get_debug_cores u_ila_0]
-set_property ALL_PROBE_SAME_MU_CNT 1 [get_debug_cores u_ila_0]
-set_property C_ADV_TRIGGER false [get_debug_cores u_ila_0]
-set_property C_DATA_DEPTH 2048 [get_debug_cores u_ila_0]
-set_property C_EN_STRG_QUAL false [get_debug_cores u_ila_0]
-set_property C_INPUT_PIPE_STAGES 0 [get_debug_cores u_ila_0]
-set_property C_TRIGIN_EN false [get_debug_cores u_ila_0]
-set_property C_TRIGOUT_EN false [get_debug_cores u_ila_0]
-set_property port_width 1 [get_debug_ports u_ila_0/clk]
-connect_debug_port u_ila_0/clk [get_nets [list u_board/u_mig_7series/u_mig_7series_mig/u_ddr2_infrastructure/CLK]]
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe0]
-set_property port_width 2 [get_debug_ports u_ila_0/probe0]
-connect_debug_port u_ila_0/probe0 [get_nets [list {eth_rxd_IBUF[0]} {eth_rxd_IBUF[1]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe1]
-set_property port_width 4 [get_debug_ports u_ila_0/probe1]
-connect_debug_port u_ila_0/probe1 [get_nets [list {mii_rxd[0]} {mii_rxd[1]} {mii_rxd[2]} {mii_rxd[3]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe2]
-set_property port_width 2 [get_debug_ports u_ila_0/probe2]
-connect_debug_port u_ila_0/probe2 [get_nets [list {eth_txd_OBUF[0]} {eth_txd_OBUF[1]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe3]
-set_property port_width 32 [get_debug_ports u_ila_0/probe3]
-connect_debug_port u_ila_0/probe3 [get_nets [list {fifo_s_axi_araddr[0]} {fifo_s_axi_araddr[1]} {fifo_s_axi_araddr[2]} {fifo_s_axi_araddr[3]} {fifo_s_axi_araddr[4]} {fifo_s_axi_araddr[5]} {fifo_s_axi_araddr[6]} {fifo_s_axi_araddr[7]} {fifo_s_axi_araddr[8]} {fifo_s_axi_araddr[9]} {fifo_s_axi_araddr[10]} {fifo_s_axi_araddr[11]} {fifo_s_axi_araddr[12]} {fifo_s_axi_araddr[13]} {fifo_s_axi_araddr[14]} {fifo_s_axi_araddr[15]} {fifo_s_axi_araddr[16]} {fifo_s_axi_araddr[17]} {fifo_s_axi_araddr[18]} {fifo_s_axi_araddr[19]} {fifo_s_axi_araddr[20]} {fifo_s_axi_araddr[21]} {fifo_s_axi_araddr[22]} {fifo_s_axi_araddr[23]} {fifo_s_axi_araddr[24]} {fifo_s_axi_araddr[25]} {fifo_s_axi_araddr[26]} {fifo_s_axi_araddr[27]} {fifo_s_axi_araddr[28]} {fifo_s_axi_araddr[29]} {fifo_s_axi_araddr[30]} {fifo_s_axi_araddr[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe4]
-set_property port_width 32 [get_debug_ports u_ila_0/probe4]
-connect_debug_port u_ila_0/probe4 [get_nets [list {fifo_s_axi_awaddr[0]} {fifo_s_axi_awaddr[1]} {fifo_s_axi_awaddr[2]} {fifo_s_axi_awaddr[3]} {fifo_s_axi_awaddr[4]} {fifo_s_axi_awaddr[5]} {fifo_s_axi_awaddr[6]} {fifo_s_axi_awaddr[7]} {fifo_s_axi_awaddr[8]} {fifo_s_axi_awaddr[9]} {fifo_s_axi_awaddr[10]} {fifo_s_axi_awaddr[11]} {fifo_s_axi_awaddr[12]} {fifo_s_axi_awaddr[13]} {fifo_s_axi_awaddr[14]} {fifo_s_axi_awaddr[15]} {fifo_s_axi_awaddr[16]} {fifo_s_axi_awaddr[17]} {fifo_s_axi_awaddr[18]} {fifo_s_axi_awaddr[19]} {fifo_s_axi_awaddr[20]} {fifo_s_axi_awaddr[21]} {fifo_s_axi_awaddr[22]} {fifo_s_axi_awaddr[23]} {fifo_s_axi_awaddr[24]} {fifo_s_axi_awaddr[25]} {fifo_s_axi_awaddr[26]} {fifo_s_axi_awaddr[27]} {fifo_s_axi_awaddr[28]} {fifo_s_axi_awaddr[29]} {fifo_s_axi_awaddr[30]} {fifo_s_axi_awaddr[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe5]
-set_property port_width 2 [get_debug_ports u_ila_0/probe5]
-connect_debug_port u_ila_0/probe5 [get_nets [list {fifo_s_axi_bresp[0]} {fifo_s_axi_bresp[1]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe6]
-set_property port_width 32 [get_debug_ports u_ila_0/probe6]
-connect_debug_port u_ila_0/probe6 [get_nets [list {fifo_s_axi_rdata[0]} {fifo_s_axi_rdata[1]} {fifo_s_axi_rdata[2]} {fifo_s_axi_rdata[3]} {fifo_s_axi_rdata[4]} {fifo_s_axi_rdata[5]} {fifo_s_axi_rdata[6]} {fifo_s_axi_rdata[7]} {fifo_s_axi_rdata[8]} {fifo_s_axi_rdata[9]} {fifo_s_axi_rdata[10]} {fifo_s_axi_rdata[11]} {fifo_s_axi_rdata[12]} {fifo_s_axi_rdata[13]} {fifo_s_axi_rdata[14]} {fifo_s_axi_rdata[15]} {fifo_s_axi_rdata[16]} {fifo_s_axi_rdata[17]} {fifo_s_axi_rdata[18]} {fifo_s_axi_rdata[19]} {fifo_s_axi_rdata[20]} {fifo_s_axi_rdata[21]} {fifo_s_axi_rdata[22]} {fifo_s_axi_rdata[23]} {fifo_s_axi_rdata[24]} {fifo_s_axi_rdata[25]} {fifo_s_axi_rdata[26]} {fifo_s_axi_rdata[27]} {fifo_s_axi_rdata[28]} {fifo_s_axi_rdata[29]} {fifo_s_axi_rdata[30]} {fifo_s_axi_rdata[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe7]
-set_property port_width 2 [get_debug_ports u_ila_0/probe7]
-connect_debug_port u_ila_0/probe7 [get_nets [list {fifo_s_axi_rresp[0]} {fifo_s_axi_rresp[1]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe8]
-set_property port_width 32 [get_debug_ports u_ila_0/probe8]
-connect_debug_port u_ila_0/probe8 [get_nets [list {fifo_s_axi_wdata[0]} {fifo_s_axi_wdata[1]} {fifo_s_axi_wdata[2]} {fifo_s_axi_wdata[3]} {fifo_s_axi_wdata[4]} {fifo_s_axi_wdata[5]} {fifo_s_axi_wdata[6]} {fifo_s_axi_wdata[7]} {fifo_s_axi_wdata[8]} {fifo_s_axi_wdata[9]} {fifo_s_axi_wdata[10]} {fifo_s_axi_wdata[11]} {fifo_s_axi_wdata[12]} {fifo_s_axi_wdata[13]} {fifo_s_axi_wdata[14]} {fifo_s_axi_wdata[15]} {fifo_s_axi_wdata[16]} {fifo_s_axi_wdata[17]} {fifo_s_axi_wdata[18]} {fifo_s_axi_wdata[19]} {fifo_s_axi_wdata[20]} {fifo_s_axi_wdata[21]} {fifo_s_axi_wdata[22]} {fifo_s_axi_wdata[23]} {fifo_s_axi_wdata[24]} {fifo_s_axi_wdata[25]} {fifo_s_axi_wdata[26]} {fifo_s_axi_wdata[27]} {fifo_s_axi_wdata[28]} {fifo_s_axi_wdata[29]} {fifo_s_axi_wdata[30]} {fifo_s_axi_wdata[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe9]
-set_property port_width 4 [get_debug_ports u_ila_0/probe9]
-connect_debug_port u_ila_0/probe9 [get_nets [list {fifo_s_axi_wstrb[0]} {fifo_s_axi_wstrb[1]} {fifo_s_axi_wstrb[2]} {fifo_s_axi_wstrb[3]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe10]
-set_property port_width 4 [get_debug_ports u_ila_0/probe10]
-connect_debug_port u_ila_0/probe10 [get_nets [list {mii_txd[0]} {mii_txd[1]} {mii_txd[2]} {mii_txd[3]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe11]
-set_property port_width 32 [get_debug_ports u_ila_0/probe11]
-connect_debug_port u_ila_0/probe11 [get_nets [list {m_axis_rxd_tdata[0]} {m_axis_rxd_tdata[1]} {m_axis_rxd_tdata[2]} {m_axis_rxd_tdata[3]} {m_axis_rxd_tdata[4]} {m_axis_rxd_tdata[5]} {m_axis_rxd_tdata[6]} {m_axis_rxd_tdata[7]} {m_axis_rxd_tdata[8]} {m_axis_rxd_tdata[9]} {m_axis_rxd_tdata[10]} {m_axis_rxd_tdata[11]} {m_axis_rxd_tdata[12]} {m_axis_rxd_tdata[13]} {m_axis_rxd_tdata[14]} {m_axis_rxd_tdata[15]} {m_axis_rxd_tdata[16]} {m_axis_rxd_tdata[17]} {m_axis_rxd_tdata[18]} {m_axis_rxd_tdata[19]} {m_axis_rxd_tdata[20]} {m_axis_rxd_tdata[21]} {m_axis_rxd_tdata[22]} {m_axis_rxd_tdata[23]} {m_axis_rxd_tdata[24]} {m_axis_rxd_tdata[25]} {m_axis_rxd_tdata[26]} {m_axis_rxd_tdata[27]} {m_axis_rxd_tdata[28]} {m_axis_rxd_tdata[29]} {m_axis_rxd_tdata[30]} {m_axis_rxd_tdata[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe12]
-set_property port_width 4 [get_debug_ports u_ila_0/probe12]
-connect_debug_port u_ila_0/probe12 [get_nets [list {m_axis_rxd_tkeep[0]} {m_axis_rxd_tkeep[1]} {m_axis_rxd_tkeep[2]} {m_axis_rxd_tkeep[3]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe13]
-set_property port_width 32 [get_debug_ports u_ila_0/probe13]
-connect_debug_port u_ila_0/probe13 [get_nets [list {s_axi_araddr[0]} {s_axi_araddr[1]} {s_axi_araddr[2]} {s_axi_araddr[3]} {s_axi_araddr[4]} {s_axi_araddr[5]} {s_axi_araddr[6]} {s_axi_araddr[7]} {s_axi_araddr[8]} {s_axi_araddr[9]} {s_axi_araddr[10]} {s_axi_araddr[11]} {s_axi_araddr[12]} {s_axi_araddr[13]} {s_axi_araddr[14]} {s_axi_araddr[15]} {s_axi_araddr[16]} {s_axi_araddr[17]} {s_axi_araddr[18]} {s_axi_araddr[19]} {s_axi_araddr[20]} {s_axi_araddr[21]} {s_axi_araddr[22]} {s_axi_araddr[23]} {s_axi_araddr[24]} {s_axi_araddr[25]} {s_axi_araddr[26]} {s_axi_araddr[27]} {s_axi_araddr[28]} {s_axi_araddr[29]} {s_axi_araddr[30]} {s_axi_araddr[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe14]
-set_property port_width 32 [get_debug_ports u_ila_0/probe14]
-connect_debug_port u_ila_0/probe14 [get_nets [list {s_axi_awaddr[0]} {s_axi_awaddr[1]} {s_axi_awaddr[2]} {s_axi_awaddr[3]} {s_axi_awaddr[4]} {s_axi_awaddr[5]} {s_axi_awaddr[6]} {s_axi_awaddr[7]} {s_axi_awaddr[8]} {s_axi_awaddr[9]} {s_axi_awaddr[10]} {s_axi_awaddr[11]} {s_axi_awaddr[12]} {s_axi_awaddr[13]} {s_axi_awaddr[14]} {s_axi_awaddr[15]} {s_axi_awaddr[16]} {s_axi_awaddr[17]} {s_axi_awaddr[18]} {s_axi_awaddr[19]} {s_axi_awaddr[20]} {s_axi_awaddr[21]} {s_axi_awaddr[22]} {s_axi_awaddr[23]} {s_axi_awaddr[24]} {s_axi_awaddr[25]} {s_axi_awaddr[26]} {s_axi_awaddr[27]} {s_axi_awaddr[28]} {s_axi_awaddr[29]} {s_axi_awaddr[30]} {s_axi_awaddr[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe15]
-set_property port_width 2 [get_debug_ports u_ila_0/probe15]
-connect_debug_port u_ila_0/probe15 [get_nets [list {s_axi_bresp[0]} {s_axi_bresp[1]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe16]
-set_property port_width 32 [get_debug_ports u_ila_0/probe16]
-connect_debug_port u_ila_0/probe16 [get_nets [list {s_axi_rdata[0]} {s_axi_rdata[1]} {s_axi_rdata[2]} {s_axi_rdata[3]} {s_axi_rdata[4]} {s_axi_rdata[5]} {s_axi_rdata[6]} {s_axi_rdata[7]} {s_axi_rdata[8]} {s_axi_rdata[9]} {s_axi_rdata[10]} {s_axi_rdata[11]} {s_axi_rdata[12]} {s_axi_rdata[13]} {s_axi_rdata[14]} {s_axi_rdata[15]} {s_axi_rdata[16]} {s_axi_rdata[17]} {s_axi_rdata[18]} {s_axi_rdata[19]} {s_axi_rdata[20]} {s_axi_rdata[21]} {s_axi_rdata[22]} {s_axi_rdata[23]} {s_axi_rdata[24]} {s_axi_rdata[25]} {s_axi_rdata[26]} {s_axi_rdata[27]} {s_axi_rdata[28]} {s_axi_rdata[29]} {s_axi_rdata[30]} {s_axi_rdata[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe17]
-set_property port_width 2 [get_debug_ports u_ila_0/probe17]
-connect_debug_port u_ila_0/probe17 [get_nets [list {s_axi_rresp[0]} {s_axi_rresp[1]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe18]
-set_property port_width 32 [get_debug_ports u_ila_0/probe18]
-connect_debug_port u_ila_0/probe18 [get_nets [list {s_axi_wdata[0]} {s_axi_wdata[1]} {s_axi_wdata[2]} {s_axi_wdata[3]} {s_axi_wdata[4]} {s_axi_wdata[5]} {s_axi_wdata[6]} {s_axi_wdata[7]} {s_axi_wdata[8]} {s_axi_wdata[9]} {s_axi_wdata[10]} {s_axi_wdata[11]} {s_axi_wdata[12]} {s_axi_wdata[13]} {s_axi_wdata[14]} {s_axi_wdata[15]} {s_axi_wdata[16]} {s_axi_wdata[17]} {s_axi_wdata[18]} {s_axi_wdata[19]} {s_axi_wdata[20]} {s_axi_wdata[21]} {s_axi_wdata[22]} {s_axi_wdata[23]} {s_axi_wdata[24]} {s_axi_wdata[25]} {s_axi_wdata[26]} {s_axi_wdata[27]} {s_axi_wdata[28]} {s_axi_wdata[29]} {s_axi_wdata[30]} {s_axi_wdata[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe19]
-set_property port_width 4 [get_debug_ports u_ila_0/probe19]
-connect_debug_port u_ila_0/probe19 [get_nets [list {s_axi_wstrb[0]} {s_axi_wstrb[1]} {s_axi_wstrb[2]} {s_axi_wstrb[3]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe20]
-set_property port_width 32 [get_debug_ports u_ila_0/probe20]
-connect_debug_port u_ila_0/probe20 [get_nets [list {s_axis_txc_tdata[0]} {s_axis_txc_tdata[1]} {s_axis_txc_tdata[2]} {s_axis_txc_tdata[3]} {s_axis_txc_tdata[4]} {s_axis_txc_tdata[5]} {s_axis_txc_tdata[6]} {s_axis_txc_tdata[7]} {s_axis_txc_tdata[8]} {s_axis_txc_tdata[9]} {s_axis_txc_tdata[10]} {s_axis_txc_tdata[11]} {s_axis_txc_tdata[12]} {s_axis_txc_tdata[13]} {s_axis_txc_tdata[14]} {s_axis_txc_tdata[15]} {s_axis_txc_tdata[16]} {s_axis_txc_tdata[17]} {s_axis_txc_tdata[18]} {s_axis_txc_tdata[19]} {s_axis_txc_tdata[20]} {s_axis_txc_tdata[21]} {s_axis_txc_tdata[22]} {s_axis_txc_tdata[23]} {s_axis_txc_tdata[24]} {s_axis_txc_tdata[25]} {s_axis_txc_tdata[26]} {s_axis_txc_tdata[27]} {s_axis_txc_tdata[28]} {s_axis_txc_tdata[29]} {s_axis_txc_tdata[30]} {s_axis_txc_tdata[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe21]
-set_property port_width 32 [get_debug_ports u_ila_0/probe21]
-connect_debug_port u_ila_0/probe21 [get_nets [list {s_axis_txd_tdata[0]} {s_axis_txd_tdata[1]} {s_axis_txd_tdata[2]} {s_axis_txd_tdata[3]} {s_axis_txd_tdata[4]} {s_axis_txd_tdata[5]} {s_axis_txd_tdata[6]} {s_axis_txd_tdata[7]} {s_axis_txd_tdata[8]} {s_axis_txd_tdata[9]} {s_axis_txd_tdata[10]} {s_axis_txd_tdata[11]} {s_axis_txd_tdata[12]} {s_axis_txd_tdata[13]} {s_axis_txd_tdata[14]} {s_axis_txd_tdata[15]} {s_axis_txd_tdata[16]} {s_axis_txd_tdata[17]} {s_axis_txd_tdata[18]} {s_axis_txd_tdata[19]} {s_axis_txd_tdata[20]} {s_axis_txd_tdata[21]} {s_axis_txd_tdata[22]} {s_axis_txd_tdata[23]} {s_axis_txd_tdata[24]} {s_axis_txd_tdata[25]} {s_axis_txd_tdata[26]} {s_axis_txd_tdata[27]} {s_axis_txd_tdata[28]} {s_axis_txd_tdata[29]} {s_axis_txd_tdata[30]} {s_axis_txd_tdata[31]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe22]
-set_property port_width 4 [get_debug_ports u_ila_0/probe22]
-connect_debug_port u_ila_0/probe22 [get_nets [list {s_axis_txd_tkeep[0]} {s_axis_txd_tkeep[1]} {s_axis_txd_tkeep[2]} {s_axis_txd_tkeep[3]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe23]
-set_property port_width 4 [get_debug_ports u_ila_0/probe23]
-connect_debug_port u_ila_0/probe23 [get_nets [list {s_axis_txc_tkeep[0]} {s_axis_txc_tkeep[1]} {s_axis_txc_tkeep[2]} {s_axis_txc_tkeep[3]}]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe24]
-set_property port_width 1 [get_debug_ports u_ila_0/probe24]
-connect_debug_port u_ila_0/probe24 [get_nets [list eth_crsdv_IBUF]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe25]
-set_property port_width 1 [get_debug_ports u_ila_0/probe25]
-connect_debug_port u_ila_0/probe25 [get_nets [list eth_mdc_OBUF]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe26]
-set_property port_width 1 [get_debug_ports u_ila_0/probe26]
-connect_debug_port u_ila_0/probe26 [get_nets [list eth_refclk_OBUF]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe27]
-set_property port_width 1 [get_debug_ports u_ila_0/probe27]
-connect_debug_port u_ila_0/probe27 [get_nets [list eth_rstn_OBUF]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe28]
-set_property port_width 1 [get_debug_ports u_ila_0/probe28]
-connect_debug_port u_ila_0/probe28 [get_nets [list eth_rxerr_IBUF]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe29]
-set_property port_width 1 [get_debug_ports u_ila_0/probe29]
-connect_debug_port u_ila_0/probe29 [get_nets [list eth_txen_OBUF]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe30]
-set_property port_width 1 [get_debug_ports u_ila_0/probe30]
-connect_debug_port u_ila_0/probe30 [get_nets [list fifo_s_axi_arready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe31]
-set_property port_width 1 [get_debug_ports u_ila_0/probe31]
-connect_debug_port u_ila_0/probe31 [get_nets [list fifo_s_axi_arvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe32]
-set_property port_width 1 [get_debug_ports u_ila_0/probe32]
-connect_debug_port u_ila_0/probe32 [get_nets [list fifo_s_axi_awready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe33]
-set_property port_width 1 [get_debug_ports u_ila_0/probe33]
-connect_debug_port u_ila_0/probe33 [get_nets [list fifo_s_axi_awvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe34]
-set_property port_width 1 [get_debug_ports u_ila_0/probe34]
-connect_debug_port u_ila_0/probe34 [get_nets [list fifo_s_axi_bready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe35]
-set_property port_width 1 [get_debug_ports u_ila_0/probe35]
-connect_debug_port u_ila_0/probe35 [get_nets [list fifo_s_axi_bvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe36]
-set_property port_width 1 [get_debug_ports u_ila_0/probe36]
-connect_debug_port u_ila_0/probe36 [get_nets [list fifo_s_axi_rready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe37]
-set_property port_width 1 [get_debug_ports u_ila_0/probe37]
-connect_debug_port u_ila_0/probe37 [get_nets [list fifo_s_axi_rvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe38]
-set_property port_width 1 [get_debug_ports u_ila_0/probe38]
-connect_debug_port u_ila_0/probe38 [get_nets [list fifo_s_axi_wready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe39]
-set_property port_width 1 [get_debug_ports u_ila_0/probe39]
-connect_debug_port u_ila_0/probe39 [get_nets [list fifo_s_axi_wvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe40]
-set_property port_width 1 [get_debug_ports u_ila_0/probe40]
-connect_debug_port u_ila_0/probe40 [get_nets [list m_axis_rxd_tlast]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe41]
-set_property port_width 1 [get_debug_ports u_ila_0/probe41]
-connect_debug_port u_ila_0/probe41 [get_nets [list m_axis_rxd_tready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe42]
-set_property port_width 1 [get_debug_ports u_ila_0/probe42]
-connect_debug_port u_ila_0/probe42 [get_nets [list m_axis_rxd_tvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe43]
-set_property port_width 1 [get_debug_ports u_ila_0/probe43]
-connect_debug_port u_ila_0/probe43 [get_nets [list s_axi_arready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe44]
-set_property port_width 1 [get_debug_ports u_ila_0/probe44]
-connect_debug_port u_ila_0/probe44 [get_nets [list s_axi_arvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe45]
-set_property port_width 1 [get_debug_ports u_ila_0/probe45]
-connect_debug_port u_ila_0/probe45 [get_nets [list s_axi_awready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe46]
-set_property port_width 1 [get_debug_ports u_ila_0/probe46]
-connect_debug_port u_ila_0/probe46 [get_nets [list s_axi_awvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe47]
-set_property port_width 1 [get_debug_ports u_ila_0/probe47]
-connect_debug_port u_ila_0/probe47 [get_nets [list s_axi_bready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe48]
-set_property port_width 1 [get_debug_ports u_ila_0/probe48]
-connect_debug_port u_ila_0/probe48 [get_nets [list s_axi_bvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe49]
-set_property port_width 1 [get_debug_ports u_ila_0/probe49]
-connect_debug_port u_ila_0/probe49 [get_nets [list s_axi_rready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe50]
-set_property port_width 1 [get_debug_ports u_ila_0/probe50]
-connect_debug_port u_ila_0/probe50 [get_nets [list s_axi_rvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe51]
-set_property port_width 1 [get_debug_ports u_ila_0/probe51]
-connect_debug_port u_ila_0/probe51 [get_nets [list s_axi_wready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe52]
-set_property port_width 1 [get_debug_ports u_ila_0/probe52]
-connect_debug_port u_ila_0/probe52 [get_nets [list s_axi_wvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe53]
-set_property port_width 1 [get_debug_ports u_ila_0/probe53]
-connect_debug_port u_ila_0/probe53 [get_nets [list s_axis_txc_tlast]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe54]
-set_property port_width 1 [get_debug_ports u_ila_0/probe54]
-connect_debug_port u_ila_0/probe54 [get_nets [list s_axis_txc_tready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe55]
-set_property port_width 1 [get_debug_ports u_ila_0/probe55]
-connect_debug_port u_ila_0/probe55 [get_nets [list s_axis_txc_tvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe56]
-set_property port_width 1 [get_debug_ports u_ila_0/probe56]
-connect_debug_port u_ila_0/probe56 [get_nets [list s_axis_txd_tlast]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe57]
-set_property port_width 1 [get_debug_ports u_ila_0/probe57]
-connect_debug_port u_ila_0/probe57 [get_nets [list s_axis_txd_tready]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe58]
-set_property port_width 1 [get_debug_ports u_ila_0/probe58]
-connect_debug_port u_ila_0/probe58 [get_nets [list s_axis_txd_tvalid]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe59]
-set_property port_width 1 [get_debug_ports u_ila_0/probe59]
-connect_debug_port u_ila_0/probe59 [get_nets [list mii_rx_clk]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe60]
-set_property port_width 1 [get_debug_ports u_ila_0/probe60]
-connect_debug_port u_ila_0/probe60 [get_nets [list mii_rx_dv]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe61]
-set_property port_width 1 [get_debug_ports u_ila_0/probe61]
-connect_debug_port u_ila_0/probe61 [get_nets [list mii_rx_er]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe62]
-set_property port_width 1 [get_debug_ports u_ila_0/probe62]
-connect_debug_port u_ila_0/probe62 [get_nets [list mii_tx_clk]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe63]
-set_property port_width 1 [get_debug_ports u_ila_0/probe63]
-connect_debug_port u_ila_0/probe63 [get_nets [list mii_tx_en]]
-create_debug_port u_ila_0 probe
-set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe64]
-set_property port_width 1 [get_debug_ports u_ila_0/probe64]
-connect_debug_port u_ila_0/probe64 [get_nets [list mii_tx_er]]
-set_property C_CLK_INPUT_FREQ_HZ 300000000 [get_debug_cores dbg_hub]
-set_property C_ENABLE_CLK_DIVIDER false [get_debug_cores dbg_hub]
-set_property C_USER_SCAN_CHAIN 1 [get_debug_cores dbg_hub]
-connect_debug_port dbg_hub/clk [get_nets sys_clk]

--- a/external/extra_cores/boards/nexys4ddr/data/pins.xdc
+++ b/external/extra_cores/boards/nexys4ddr/data/pins.xdc
@@ -6,87 +6,44 @@
 ## https://reference.digilentinc.com/_media/nexys4-ddr:nexys4ddr_rm.pdf
 
 ## 100 MHz Clock signal
-set_property -quiet -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports -quiet { clk }]; #IO_L12P_T1_MRCC_35 Sch=clk100mhz
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports -quiet {clk}];
+set_property -dict {PACKAGE_PIN E3 IOSTANDARD LVCMOS33} [get_ports -quiet clk]
+create_clock -period 10.000 -name sys_clk_pin -waveform {0.000 5.000} -add [get_ports -quiet clk]
 
 
 ## Switches
 
-set_property -quiet -dict { PACKAGE_PIN J15   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[0] }]; #IO_L24N_T3_RS0_15 Sch=sw[0]
-set_property -quiet -dict { PACKAGE_PIN L16   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[1] }]; #IO_L3N_T0_DQS_EMCCLK_14 Sch=sw[1]
-set_property -quiet -dict { PACKAGE_PIN M13   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[2] }]; #IO_L6N_T0_D08_VREF_14 Sch=sw[2]
-set_property -quiet -dict { PACKAGE_PIN R15   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[3] }]; #IO_L13N_T2_MRCC_14 Sch=sw[3]
-set_property -quiet -dict { PACKAGE_PIN R17   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[4] }]; #IO_L12N_T1_MRCC_14 Sch=sw[4]
-set_property -quiet -dict { PACKAGE_PIN T18   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[5] }]; #IO_L7N_T1_D10_14 Sch=sw[5]
-set_property -quiet -dict { PACKAGE_PIN U18   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[6] }]; #IO_L17N_T2_A13_D29_14 Sch=sw[6]
-set_property -quiet -dict { PACKAGE_PIN R13   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[7] }]; #IO_L5N_T0_D07_14 Sch=sw[7]
-set_property -quiet -dict { PACKAGE_PIN T8    IOSTANDARD LVCMOS18 } [get_ports -quiet { sw[8] }]; #IO_L24N_T3_34 Sch=sw[8]
-set_property -quiet -dict { PACKAGE_PIN U8    IOSTANDARD LVCMOS18 } [get_ports -quiet { sw[9] }]; #IO_25_34 Sch=sw[9]
-set_property -quiet -dict { PACKAGE_PIN R16   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[10] }]; #IO_L15P_T2_DQS_RDWR_B_14 Sch=sw[10]
-set_property -quiet -dict { PACKAGE_PIN T13   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[11] }]; #IO_L23P_T3_A03_D19_14 Sch=sw[11]
-set_property -quiet -dict { PACKAGE_PIN H6    IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[12] }]; #IO_L24P_T3_35 Sch=sw[12]
-set_property -quiet -dict { PACKAGE_PIN U12   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[13] }]; #IO_L20P_T3_A08_D24_14 Sch=sw[13]
-set_property -quiet -dict { PACKAGE_PIN U11   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[14] }]; #IO_L19N_T3_A09_D25_VREF_14 Sch=sw[14]
-set_property -quiet -dict { PACKAGE_PIN V10   IOSTANDARD LVCMOS33 } [get_ports -quiet { sw[15] }]; #IO_L21P_T3_DQS_14 Sch=sw[15]
 
 
 ## LEDs
 
-set_property -quiet -dict { PACKAGE_PIN H17   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[0] }]; #IO_L18P_T2_A24_15 Sch=led[0]
-set_property -quiet -dict { PACKAGE_PIN K15   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[1] }]; #IO_L24P_T3_RS1_15 Sch=led[1]
-set_property -quiet -dict { PACKAGE_PIN J13   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[2] }]; #IO_L17N_T2_A25_15 Sch=led[2]
-set_property -quiet -dict { PACKAGE_PIN N14   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[3] }]; #IO_L8P_T1_D11_14 Sch=led[3]
-set_property -quiet -dict { PACKAGE_PIN R18   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[4] }]; #IO_L7P_T1_D09_14 Sch=led[4]
-set_property -quiet -dict { PACKAGE_PIN V17   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[5] }]; #IO_L18N_T2_A11_D27_14 Sch=led[5]
-set_property -quiet -dict { PACKAGE_PIN U17   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[6] }]; #IO_L17P_T2_A14_D30_14 Sch=led[6]
-set_property -quiet -dict { PACKAGE_PIN U16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[7] }]; #IO_L18P_T2_A12_D28_14 Sch=led[7]
-set_property -quiet -dict { PACKAGE_PIN V16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[8] }]; #IO_L16N_T2_A15_D31_14 Sch=led[8]
-set_property -quiet -dict { PACKAGE_PIN T15   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[9] }]; #IO_L14N_T2_SRCC_14 Sch=led[9]
-set_property -quiet -dict { PACKAGE_PIN U14   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[10] }]; #IO_L22P_T3_A05_D21_14 Sch=led[10]
-set_property -quiet -dict { PACKAGE_PIN T16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[11] }]; #IO_L15N_T2_DQS_DOUT_CSO_B_14 Sch=led[11]
-set_property -quiet -dict { PACKAGE_PIN V15   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[12] }]; #IO_L16P_T2_CSI_B_14 Sch=led[12]
-set_property -quiet -dict { PACKAGE_PIN V14   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[13] }]; #IO_L22N_T3_A04_D20_14 Sch=led[13]
-set_property -quiet -dict { PACKAGE_PIN V12   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[14] }]; #IO_L20N_T3_A07_D23_14 Sch=led[14]
-set_property -quiet -dict { PACKAGE_PIN V11   IOSTANDARD LVCMOS33 } [get_ports -quiet { led[15] }]; #IO_L21N_T3_DQS_A06_D22_14 Sch=led[15]
+set_property -dict {PACKAGE_PIN H17 IOSTANDARD LVCMOS33} [get_ports -quiet {led[0]}]
+set_property -dict {PACKAGE_PIN K15 IOSTANDARD LVCMOS33} [get_ports -quiet {led[1]}]
+set_property -dict {PACKAGE_PIN J13 IOSTANDARD LVCMOS33} [get_ports -quiet {led[2]}]
+set_property -dict {PACKAGE_PIN N14 IOSTANDARD LVCMOS33} [get_ports -quiet {led[3]}]
+set_property -dict {PACKAGE_PIN R18 IOSTANDARD LVCMOS33} [get_ports -quiet {led[4]}]
+set_property -dict {PACKAGE_PIN V17 IOSTANDARD LVCMOS33} [get_ports -quiet {led[5]}]
+set_property -dict {PACKAGE_PIN U17 IOSTANDARD LVCMOS33} [get_ports -quiet {led[6]}]
+set_property -dict {PACKAGE_PIN U16 IOSTANDARD LVCMOS33} [get_ports -quiet {led[7]}]
+set_property -dict {PACKAGE_PIN V16 IOSTANDARD LVCMOS33} [get_ports -quiet {led[8]}]
+set_property -dict {PACKAGE_PIN T15 IOSTANDARD LVCMOS33} [get_ports -quiet {led[9]}]
+set_property -dict {PACKAGE_PIN U14 IOSTANDARD LVCMOS33} [get_ports -quiet {led[10]}]
+set_property -dict {PACKAGE_PIN T16 IOSTANDARD LVCMOS33} [get_ports -quiet {led[11]}]
+set_property -dict {PACKAGE_PIN V15 IOSTANDARD LVCMOS33} [get_ports -quiet {led[12]}]
+set_property -dict {PACKAGE_PIN V14 IOSTANDARD LVCMOS33} [get_ports -quiet {led[13]}]
+set_property -dict {PACKAGE_PIN V12 IOSTANDARD LVCMOS33} [get_ports -quiet {led[14]}]
+set_property -dict {PACKAGE_PIN V11 IOSTANDARD LVCMOS33} [get_ports -quiet {led[15]}]
 
-set_property -quiet -dict { PACKAGE_PIN R12   IOSTANDARD LVCMOS33 } [get_ports -quiet { led16_b }]; #IO_L5P_T0_D06_14 Sch=led16_b
-set_property -quiet -dict { PACKAGE_PIN M16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led16_g }]; #IO_L10P_T1_D14_14 Sch=led16_g
-set_property -quiet -dict { PACKAGE_PIN N15   IOSTANDARD LVCMOS33 } [get_ports -quiet { led16_r }]; #IO_L11P_T1_SRCC_14 Sch=led16_r
-set_property -quiet -dict { PACKAGE_PIN G14   IOSTANDARD LVCMOS33 } [get_ports -quiet { led17_b }]; #IO_L15N_T2_DQS_ADV_B_15 Sch=led17_b
-set_property -quiet -dict { PACKAGE_PIN R11   IOSTANDARD LVCMOS33 } [get_ports -quiet { led17_g }]; #IO_0_14 Sch=led17_g
-set_property -quiet -dict { PACKAGE_PIN N16   IOSTANDARD LVCMOS33 } [get_ports -quiet { led17_r }]; #IO_L11N_T1_SRCC_14 Sch=led17_r
 
 
 ## 7 segment display
 
-set_property -quiet -dict { PACKAGE_PIN T10   IOSTANDARD LVCMOS33 } [get_ports -quiet { ca }]; #IO_L24N_T3_A00_D16_14 Sch=ca
-set_property -quiet -dict { PACKAGE_PIN R10   IOSTANDARD LVCMOS33 } [get_ports -quiet { cb }]; #IO_25_14 Sch=cb
-set_property -quiet -dict { PACKAGE_PIN K16   IOSTANDARD LVCMOS33 } [get_ports -quiet { cc }]; #IO_25_15 Sch=cc
-set_property -quiet -dict { PACKAGE_PIN K13   IOSTANDARD LVCMOS33 } [get_ports -quiet { cd }]; #IO_L17P_T2_A26_15 Sch=cd
-set_property -quiet -dict { PACKAGE_PIN P15   IOSTANDARD LVCMOS33 } [get_ports -quiet { ce }]; #IO_L13P_T2_MRCC_14 Sch=ce
-set_property -quiet -dict { PACKAGE_PIN T11   IOSTANDARD LVCMOS33 } [get_ports -quiet { cf }]; #IO_L19P_T3_A10_D26_14 Sch=cf
-set_property -quiet -dict { PACKAGE_PIN L18   IOSTANDARD LVCMOS33 } [get_ports -quiet { cg }]; #IO_L4P_T0_D04_14 Sch=cg
 
-set_property -quiet -dict { PACKAGE_PIN H15   IOSTANDARD LVCMOS33 } [get_ports -quiet { dp }]; #IO_L19N_T3_A21_VREF_15 Sch=dp
 
-set_property -quiet -dict { PACKAGE_PIN J17   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[0] }]; #IO_L23P_T3_FOE_B_15 Sch=an[0]
-set_property -quiet -dict { PACKAGE_PIN J18   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[1] }]; #IO_L23N_T3_FWE_B_15 Sch=an[1]
-set_property -quiet -dict { PACKAGE_PIN T9    IOSTANDARD LVCMOS33 } [get_ports -quiet { an[2] }]; #IO_L24P_T3_A01_D17_14 Sch=an[2]
-set_property -quiet -dict { PACKAGE_PIN J14   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[3] }]; #IO_L19P_T3_A22_15 Sch=an[3]
-set_property -quiet -dict { PACKAGE_PIN P14   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[4] }]; #IO_L8N_T1_D12_14 Sch=an[4]
-set_property -quiet -dict { PACKAGE_PIN T14   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[5] }]; #IO_L14P_T2_SRCC_14 Sch=an[5]
-set_property -quiet -dict { PACKAGE_PIN K2    IOSTANDARD LVCMOS33 } [get_ports -quiet { an[6] }]; #IO_L23P_T3_35 Sch=an[6]
-set_property -quiet -dict { PACKAGE_PIN U13   IOSTANDARD LVCMOS33 } [get_ports -quiet { an[7] }]; #IO_L23N_T3_A02_D18_14 Sch=an[7]
 
 ## Buttons
 
-set_property -quiet -dict { PACKAGE_PIN C12   IOSTANDARD LVCMOS33 } [get_ports -quiet { cpu_resetn }]; #IO_L3P_T0_DQS_AD1P_15 Sch=cpu_resetn
+set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS33} [get_ports -quiet cpu_resetn]
 
-set_property -quiet -dict { PACKAGE_PIN N17   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnc }]; #IO_L9P_T1_DQS_14 Sch=btnc
-set_property -quiet -dict { PACKAGE_PIN M18   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnu }]; #IO_L4N_T0_D05_14 Sch=btnu
-set_property -quiet -dict { PACKAGE_PIN P17   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnl }]; #IO_L12P_T1_MRCC_14 Sch=btnl
-set_property -quiet -dict { PACKAGE_PIN M17   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnr }]; #IO_L10N_T1_D15_14 Sch=btnr
-set_property -quiet -dict { PACKAGE_PIN P18   IOSTANDARD LVCMOS33 } [get_ports -quiet { btnd }]; #IO_L9N_T1_DQS_D13_14 Sch=btnd
 
 
 ## Pmod Headers
@@ -94,62 +51,22 @@ set_property -quiet -dict { PACKAGE_PIN P18   IOSTANDARD LVCMOS33 } [get_ports -
 
 ## Pmod Header JA
 
-set_property -quiet -dict { PACKAGE_PIN C17   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[0] }]; #IO_L20N_T3_A19_15 Sch=ja[1]
-set_property -quiet -dict { PACKAGE_PIN D18   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[1] }]; #IO_L21N_T3_DQS_A18_15 Sch=ja[2]
-set_property -quiet -dict { PACKAGE_PIN E18   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[2] }]; #IO_L21P_T3_DQS_15 Sch=ja[3]
-set_property -quiet -dict { PACKAGE_PIN G17   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[3] }]; #IO_L18N_T2_A23_15 Sch=ja[4]
-set_property -quiet -dict { PACKAGE_PIN D17   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[4] }]; #IO_L16N_T2_A27_15 Sch=ja[7]
-set_property -quiet -dict { PACKAGE_PIN E17   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[5] }]; #IO_L16P_T2_A28_15 Sch=ja[8]
-set_property -quiet -dict { PACKAGE_PIN F18   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[6] }]; #IO_L22N_T3_A16_15 Sch=ja[9]
-set_property -quiet -dict { PACKAGE_PIN G18   IOSTANDARD LVCMOS33 } [get_ports -quiet { ja[7] }]; #IO_L22P_T3_A17_15 Sch=ja[10]
 
 
 ## Pmod Header JB
 
-set_property -quiet -dict { PACKAGE_PIN D14   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[0] }]; #IO_L1P_T0_AD0P_15 Sch=jb[1]
-set_property -quiet -dict { PACKAGE_PIN F16   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[1] }]; #IO_L14N_T2_SRCC_15 Sch=jb[2]
-set_property -quiet -dict { PACKAGE_PIN G16   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[2] }]; #IO_L13N_T2_MRCC_15 Sch=jb[3]
-set_property -quiet -dict { PACKAGE_PIN H14   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[3] }]; #IO_L15P_T2_DQS_15 Sch=jb[4]
-set_property -quiet -dict { PACKAGE_PIN E16   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[4] }]; #IO_L11N_T1_SRCC_15 Sch=jb[7]
-set_property -quiet -dict { PACKAGE_PIN F13   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[5] }]; #IO_L5P_T0_AD9P_15 Sch=jb[8]
-set_property -quiet -dict { PACKAGE_PIN G13   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[6] }]; #IO_0_15 Sch=jb[9]
-set_property -quiet -dict { PACKAGE_PIN H16   IOSTANDARD LVCMOS33 } [get_ports -quiet { jb[7] }]; #IO_L13P_T2_MRCC_15 Sch=jb[10]
 
 
 ## Pmod Header JC
 
-set_property -quiet -dict { PACKAGE_PIN K1    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[0] }]; #IO_L23N_T3_35 Sch=jc[1]
-set_property -quiet -dict { PACKAGE_PIN F6    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[1] }]; #IO_L19N_T3_VREF_35 Sch=jc[2]
-set_property -quiet -dict { PACKAGE_PIN J2    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[2] }]; #IO_L22N_T3_35 Sch=jc[3]
-set_property -quiet -dict { PACKAGE_PIN G6    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[3] }]; #IO_L19P_T3_35 Sch=jc[4]
-set_property -quiet -dict { PACKAGE_PIN E7    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[4] }]; #IO_L6P_T0_35 Sch=jc[7]
-set_property -quiet -dict { PACKAGE_PIN J3    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[5] }]; #IO_L22P_T3_35 Sch=jc[8]
-set_property -quiet -dict { PACKAGE_PIN J4    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[6] }]; #IO_L21P_T3_DQS_35 Sch=jc[9]
-set_property -quiet -dict { PACKAGE_PIN E6    IOSTANDARD LVCMOS33 } [get_ports -quiet { jc[7] }]; #IO_L5P_T0_AD13P_35 Sch=jc[10]
 
 
 ## Pmod Header JD
 
-set_property -quiet -dict { PACKAGE_PIN H4    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[0] }]; #IO_L21N_T3_DQS_35 Sch=jd[1]
-set_property -quiet -dict { PACKAGE_PIN H1    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[1] }]; #IO_L17P_T2_35 Sch=jd[2]
-set_property -quiet -dict { PACKAGE_PIN G1    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[2] }]; #IO_L17N_T2_35 Sch=jd[3]
-set_property -quiet -dict { PACKAGE_PIN G3    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[3] }]; #IO_L20N_T3_35 Sch=jd[4]
-set_property -quiet -dict { PACKAGE_PIN H2    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[4] }]; #IO_L15P_T2_DQS_35 Sch=jd[7]
-set_property -quiet -dict { PACKAGE_PIN G4    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[5] }]; #IO_L20P_T3_35 Sch=jd[8]
-set_property -quiet -dict { PACKAGE_PIN G2    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[6] }]; #IO_L15N_T2_DQS_35 Sch=jd[9]
-set_property -quiet -dict { PACKAGE_PIN F3    IOSTANDARD LVCMOS33 } [get_ports -quiet { jd[7] }]; #IO_L13N_T2_MRCC_35 Sch=jd[10]
 
 
 ## Pmod Header JXADC
 
-set_property -quiet -dict { PACKAGE_PIN A14   IOSTANDARD LVDS     } [get_ports -quiet { xa_n[0] }]; #IO_L9N_T1_DQS_AD3N_15 Sch=xa_n[1]
-set_property -quiet -dict { PACKAGE_PIN A13   IOSTANDARD LVDS     } [get_ports -quiet { xa_p[0] }]; #IO_L9P_T1_DQS_AD3P_15 Sch=xa_p[1]
-set_property -quiet -dict { PACKAGE_PIN A16   IOSTANDARD LVDS     } [get_ports -quiet { xa_n[1] }]; #IO_L8N_T1_AD10N_15 Sch=xa_n[2]
-set_property -quiet -dict { PACKAGE_PIN A15   IOSTANDARD LVDS     } [get_ports -quiet { xa_p[1] }]; #IO_L8P_T1_AD10P_15 Sch=xa_p[2]
-set_property -quiet -dict { PACKAGE_PIN B17   IOSTANDARD LVDS     } [get_ports -quiet { xa_n[2] }]; #IO_L7N_T1_AD2N_15 Sch=xa_n[3]
-set_property -quiet -dict { PACKAGE_PIN B16   IOSTANDARD LVDS     } [get_ports -quiet { xa_p[2] }]; #IO_L7P_T1_AD2P_15 Sch=xa_p[3]
-set_property -quiet -dict { PACKAGE_PIN A18   IOSTANDARD LVDS     } [get_ports -quiet { xa_n[3] }]; #IO_L10N_T1_AD11N_15 Sch=xa_n[4]
-set_property -quiet -dict { PACKAGE_PIN B18   IOSTANDARD LVDS     } [get_ports -quiet { xa_p[3] }]; #IO_L10P_T1_AD11P_15 Sch=xa_p[4]
 
 
 ## VGA Connector
@@ -218,12 +135,12 @@ set_property -quiet -dict { PACKAGE_PIN B18   IOSTANDARD LVDS     } [get_ports -
 ## USB-RS232 Interface
 ## From FT2232H: http://www.ftdichip.com/Support/Documents/DataSheets/ICs/DS_FT2232H.pdf
 ## We left the pin names as they are used by Digilent, even though they are confusing for CTS/RTS
-set_property -quiet -dict { PACKAGE_PIN C4    IOSTANDARD LVCMOS33 } [get_ports -quiet { uart_txd_in }]; #IO_L7P_T1_AD6P_35 Sch=uart_txd_in
-set_property -quiet -dict { PACKAGE_PIN D4    IOSTANDARD LVCMOS33 } [get_ports -quiet { uart_rxd_out }]; #IO_L11N_T1_SRCC_35 Sch=uart_rxd_out
+set_property -dict {PACKAGE_PIN C4 IOSTANDARD LVCMOS33} [get_ports -quiet uart_txd_in]
+set_property -dict {PACKAGE_PIN D4 IOSTANDARD LVCMOS33} [get_ports -quiet uart_rxd_out]
 # CTS from the PC (output on the FPGA); active low (despite the name)
-set_property -quiet -dict { PACKAGE_PIN D3    IOSTANDARD LVCMOS33 } [get_ports -quiet { uart_cts }]; #IO_L12N_T1_MRCC_35 Sch=uart_cts
+set_property -dict {PACKAGE_PIN D3 IOSTANDARD LVCMOS33} [get_ports -quiet uart_cts]
 # RTS from the PC (input on the FPGA); active low (despite the name)
-set_property -quiet -dict { PACKAGE_PIN E5    IOSTANDARD LVCMOS33 } [get_ports -quiet { uart_rts }]; #IO_L5N_T0_AD13N_35 Sch=uart_rts
+set_property -dict {PACKAGE_PIN E5 IOSTANDARD LVCMOS33} [get_ports -quiet uart_rts]
 
 ## USB HID (PS/2)
 
@@ -233,18 +150,17 @@ set_property -quiet -dict { PACKAGE_PIN E5    IOSTANDARD LVCMOS33 } [get_ports -
 
 ## SMSC Ethernet PHY
 
-#set_property -quiet -dict { PACKAGE_PIN C9    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_mdc }]; #IO_L11P_T1_SRCC_16 Sch=eth_mdc
-#set_property -quiet -dict { PACKAGE_PIN A9    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_mdio }]; #IO_L14N_T2_SRCC_16 Sch=eth_mdio
-#set_property -quiet -dict { PACKAGE_PIN B3    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_rstn }]; #IO_L10P_T1_AD15P_35 Sch=eth_rstn
-#set_property -quiet -dict { PACKAGE_PIN D9    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_crsdv }]; #IO_L6N_T0_VREF_16 Sch=eth_crsdv
-#set_property -quiet -dict { PACKAGE_PIN C10   IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_rxerr }]; #IO_L13N_T2_MRCC_16 Sch=eth_rxerr
-#set_property -quiet -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_rxd[0] }]; #IO_L13P_T2_MRCC_16 Sch=eth_rxd[0]
-#set_property -quiet -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_rxd[1] }]; #IO_L19N_T3_VREF_16 Sch=eth_rxd[1]
-#set_property -quiet -dict { PACKAGE_PIN B9    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_txen }]; #IO_L11N_T1_SRCC_16 Sch=eth_txen
-#set_property -quiet -dict { PACKAGE_PIN A10   IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_txd[0] }]; #IO_L14P_T2_SRCC_16 Sch=eth_txd[0]
-#set_property -quiet -dict { PACKAGE_PIN A8    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_txd[1] }]; #IO_L12N_T1_MRCC_16 Sch=eth_txd[1]
-#set_property -quiet -dict { PACKAGE_PIN D5    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_refclk }]; #IO_L11P_T1_SRCC_35 Sch=eth_refclk
-#set_property -quiet -dict { PACKAGE_PIN B8    IOSTANDARD LVCMOS33 } [get_ports -quiet { eth_intn }]; #IO_L12P_T1_MRCC_16 Sch=eth_intn
+set_property -dict {PACKAGE_PIN C9 IOSTANDARD LVCMOS33} [get_ports -quiet eth_mdc]
+set_property -dict {PACKAGE_PIN A9 IOSTANDARD LVCMOS33} [get_ports -quiet eth_mdio]
+set_property -dict {PACKAGE_PIN B3 IOSTANDARD LVCMOS33} [get_ports -quiet eth_rstn]
+set_property -dict {PACKAGE_PIN D9 IOSTANDARD LVCMOS33} [get_ports -quiet eth_crsdv]
+set_property -dict {PACKAGE_PIN C10 IOSTANDARD LVCMOS33} [get_ports -quiet eth_rxerr]
+set_property -dict {PACKAGE_PIN C11 IOSTANDARD LVCMOS33} [get_ports -quiet {eth_rxd[0]}]
+set_property -dict {PACKAGE_PIN D10 IOSTANDARD LVCMOS33} [get_ports -quiet {eth_rxd[1]}]
+set_property -dict {PACKAGE_PIN B9 IOSTANDARD LVCMOS33} [get_ports -quiet eth_txen]
+set_property -dict {PACKAGE_PIN A10 IOSTANDARD LVCMOS33} [get_ports -quiet {eth_txd[0]}]
+set_property -dict {PACKAGE_PIN A8 IOSTANDARD LVCMOS33} [get_ports -quiet {eth_txd[1]}]
+set_property -dict {PACKAGE_PIN D5 IOSTANDARD LVCMOS33} [get_ports -quiet eth_refclk]
 
 
 ## Quad SPI Flash
@@ -254,3 +170,296 @@ set_property -quiet -dict { PACKAGE_PIN E5    IOSTANDARD LVCMOS33 } [get_ports -
 #set_property -quiet -dict { PACKAGE_PIN L14   IOSTANDARD LVCMOS33 } [get_ports -quiet { qspi_dq[2] }]; #IO_L2P_T0_D02_14 Sch=qspi_dq[2]
 #set_property -quiet -dict { PACKAGE_PIN M14   IOSTANDARD LVCMOS33 } [get_ports -quiet { qspi_dq[3] }]; #IO_L2N_T0_D03_14 Sch=qspi_dq[3]
 #set_property -quiet -dict { PACKAGE_PIN L13   IOSTANDARD LVCMOS33 } [get_ports -quiet { qspi_csn }]; #IO_L6P_T0_FCS_B_14 Sch=qspi_csn
+
+
+
+
+
+
+connect_debug_port u_ila_0/probe0 [get_nets [list {s_axis_txd_tkeep[0]} {s_axis_txd_tkeep[1]} {s_axis_txd_tkeep[2]} {s_axis_txd_tkeep[3]}]]
+connect_debug_port u_ila_0/probe2 [get_nets [list {s_axis_txc_tkeep[0]} {s_axis_txc_tkeep[1]} {s_axis_txc_tkeep[2]} {s_axis_txc_tkeep[3]}]]
+connect_debug_port u_ila_0/probe4 [get_nets [list {s_axi_wstrb[0]} {s_axi_wstrb[1]} {s_axi_wstrb[2]} {s_axi_wstrb[3]}]]
+connect_debug_port u_ila_0/probe5 [get_nets [list {s_axi_wdata[0]} {s_axi_wdata[1]} {s_axi_wdata[2]} {s_axi_wdata[3]} {s_axi_wdata[4]} {s_axi_wdata[5]} {s_axi_wdata[6]} {s_axi_wdata[7]} {s_axi_wdata[8]} {s_axi_wdata[9]} {s_axi_wdata[10]} {s_axi_wdata[11]} {s_axi_wdata[12]} {s_axi_wdata[13]} {s_axi_wdata[14]} {s_axi_wdata[15]} {s_axi_wdata[16]} {s_axi_wdata[17]} {s_axi_wdata[18]} {s_axi_wdata[19]} {s_axi_wdata[20]} {s_axi_wdata[21]} {s_axi_wdata[22]} {s_axi_wdata[23]} {s_axi_wdata[24]} {s_axi_wdata[25]} {s_axi_wdata[26]} {s_axi_wdata[27]} {s_axi_wdata[28]} {s_axi_wdata[29]} {s_axi_wdata[30]} {s_axi_wdata[31]}]]
+connect_debug_port u_ila_0/probe9 [get_nets [list {s_axi_awaddr[0]} {s_axi_awaddr[1]} {s_axi_awaddr[2]} {s_axi_awaddr[3]} {s_axi_awaddr[4]} {s_axi_awaddr[5]} {s_axi_awaddr[6]} {s_axi_awaddr[7]} {s_axi_awaddr[8]} {s_axi_awaddr[9]} {s_axi_awaddr[10]} {s_axi_awaddr[11]} {s_axi_awaddr[12]} {s_axi_awaddr[13]} {s_axi_awaddr[14]} {s_axi_awaddr[15]} {s_axi_awaddr[16]} {s_axi_awaddr[17]} {s_axi_awaddr[18]} {s_axi_awaddr[19]} {s_axi_awaddr[20]} {s_axi_awaddr[21]} {s_axi_awaddr[22]} {s_axi_awaddr[23]} {s_axi_awaddr[24]} {s_axi_awaddr[25]} {s_axi_awaddr[26]} {s_axi_awaddr[27]} {s_axi_awaddr[28]} {s_axi_awaddr[29]} {s_axi_awaddr[30]} {s_axi_awaddr[31]}]]
+connect_debug_port u_ila_0/probe10 [get_nets [list {s_axi_araddr[0]} {s_axi_araddr[1]} {s_axi_araddr[2]} {s_axi_araddr[3]} {s_axi_araddr[4]} {s_axi_araddr[5]} {s_axi_araddr[6]} {s_axi_araddr[7]} {s_axi_araddr[8]} {s_axi_araddr[9]} {s_axi_araddr[10]} {s_axi_araddr[11]} {s_axi_araddr[12]} {s_axi_araddr[13]} {s_axi_araddr[14]} {s_axi_araddr[15]} {s_axi_araddr[16]} {s_axi_araddr[17]} {s_axi_araddr[18]} {s_axi_araddr[19]} {s_axi_araddr[20]} {s_axi_araddr[21]} {s_axi_araddr[22]} {s_axi_araddr[23]} {s_axi_araddr[24]} {s_axi_araddr[25]} {s_axi_araddr[26]} {s_axi_araddr[27]} {s_axi_araddr[28]} {s_axi_araddr[29]} {s_axi_araddr[30]} {s_axi_araddr[31]}]]
+connect_debug_port u_ila_0/probe11 [get_nets [list {m_axis_rxd_tkeep[0]} {m_axis_rxd_tkeep[1]} {m_axis_rxd_tkeep[2]} {m_axis_rxd_tkeep[3]}]]
+connect_debug_port u_ila_0/probe28 [get_nets [list s_axi_bready]]
+connect_debug_port u_ila_0/probe30 [get_nets [list s_axi_rready]]
+
+
+
+
+create_debug_core u_ila_0 ila
+set_property ALL_PROBE_SAME_MU true [get_debug_cores u_ila_0]
+set_property ALL_PROBE_SAME_MU_CNT 1 [get_debug_cores u_ila_0]
+set_property C_ADV_TRIGGER false [get_debug_cores u_ila_0]
+set_property C_DATA_DEPTH 2048 [get_debug_cores u_ila_0]
+set_property C_EN_STRG_QUAL false [get_debug_cores u_ila_0]
+set_property C_INPUT_PIPE_STAGES 0 [get_debug_cores u_ila_0]
+set_property C_TRIGIN_EN false [get_debug_cores u_ila_0]
+set_property C_TRIGOUT_EN false [get_debug_cores u_ila_0]
+set_property port_width 1 [get_debug_ports u_ila_0/clk]
+connect_debug_port u_ila_0/clk [get_nets [list u_board/u_mig_7series/u_mig_7series_mig/u_ddr2_infrastructure/CLK]]
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe0]
+set_property port_width 2 [get_debug_ports u_ila_0/probe0]
+connect_debug_port u_ila_0/probe0 [get_nets [list {eth_rxd_IBUF[0]} {eth_rxd_IBUF[1]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe1]
+set_property port_width 4 [get_debug_ports u_ila_0/probe1]
+connect_debug_port u_ila_0/probe1 [get_nets [list {mii_rxd[0]} {mii_rxd[1]} {mii_rxd[2]} {mii_rxd[3]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe2]
+set_property port_width 2 [get_debug_ports u_ila_0/probe2]
+connect_debug_port u_ila_0/probe2 [get_nets [list {eth_txd_OBUF[0]} {eth_txd_OBUF[1]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe3]
+set_property port_width 32 [get_debug_ports u_ila_0/probe3]
+connect_debug_port u_ila_0/probe3 [get_nets [list {fifo_s_axi_araddr[0]} {fifo_s_axi_araddr[1]} {fifo_s_axi_araddr[2]} {fifo_s_axi_araddr[3]} {fifo_s_axi_araddr[4]} {fifo_s_axi_araddr[5]} {fifo_s_axi_araddr[6]} {fifo_s_axi_araddr[7]} {fifo_s_axi_araddr[8]} {fifo_s_axi_araddr[9]} {fifo_s_axi_araddr[10]} {fifo_s_axi_araddr[11]} {fifo_s_axi_araddr[12]} {fifo_s_axi_araddr[13]} {fifo_s_axi_araddr[14]} {fifo_s_axi_araddr[15]} {fifo_s_axi_araddr[16]} {fifo_s_axi_araddr[17]} {fifo_s_axi_araddr[18]} {fifo_s_axi_araddr[19]} {fifo_s_axi_araddr[20]} {fifo_s_axi_araddr[21]} {fifo_s_axi_araddr[22]} {fifo_s_axi_araddr[23]} {fifo_s_axi_araddr[24]} {fifo_s_axi_araddr[25]} {fifo_s_axi_araddr[26]} {fifo_s_axi_araddr[27]} {fifo_s_axi_araddr[28]} {fifo_s_axi_araddr[29]} {fifo_s_axi_araddr[30]} {fifo_s_axi_araddr[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe4]
+set_property port_width 32 [get_debug_ports u_ila_0/probe4]
+connect_debug_port u_ila_0/probe4 [get_nets [list {fifo_s_axi_awaddr[0]} {fifo_s_axi_awaddr[1]} {fifo_s_axi_awaddr[2]} {fifo_s_axi_awaddr[3]} {fifo_s_axi_awaddr[4]} {fifo_s_axi_awaddr[5]} {fifo_s_axi_awaddr[6]} {fifo_s_axi_awaddr[7]} {fifo_s_axi_awaddr[8]} {fifo_s_axi_awaddr[9]} {fifo_s_axi_awaddr[10]} {fifo_s_axi_awaddr[11]} {fifo_s_axi_awaddr[12]} {fifo_s_axi_awaddr[13]} {fifo_s_axi_awaddr[14]} {fifo_s_axi_awaddr[15]} {fifo_s_axi_awaddr[16]} {fifo_s_axi_awaddr[17]} {fifo_s_axi_awaddr[18]} {fifo_s_axi_awaddr[19]} {fifo_s_axi_awaddr[20]} {fifo_s_axi_awaddr[21]} {fifo_s_axi_awaddr[22]} {fifo_s_axi_awaddr[23]} {fifo_s_axi_awaddr[24]} {fifo_s_axi_awaddr[25]} {fifo_s_axi_awaddr[26]} {fifo_s_axi_awaddr[27]} {fifo_s_axi_awaddr[28]} {fifo_s_axi_awaddr[29]} {fifo_s_axi_awaddr[30]} {fifo_s_axi_awaddr[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe5]
+set_property port_width 2 [get_debug_ports u_ila_0/probe5]
+connect_debug_port u_ila_0/probe5 [get_nets [list {fifo_s_axi_bresp[0]} {fifo_s_axi_bresp[1]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe6]
+set_property port_width 32 [get_debug_ports u_ila_0/probe6]
+connect_debug_port u_ila_0/probe6 [get_nets [list {fifo_s_axi_rdata[0]} {fifo_s_axi_rdata[1]} {fifo_s_axi_rdata[2]} {fifo_s_axi_rdata[3]} {fifo_s_axi_rdata[4]} {fifo_s_axi_rdata[5]} {fifo_s_axi_rdata[6]} {fifo_s_axi_rdata[7]} {fifo_s_axi_rdata[8]} {fifo_s_axi_rdata[9]} {fifo_s_axi_rdata[10]} {fifo_s_axi_rdata[11]} {fifo_s_axi_rdata[12]} {fifo_s_axi_rdata[13]} {fifo_s_axi_rdata[14]} {fifo_s_axi_rdata[15]} {fifo_s_axi_rdata[16]} {fifo_s_axi_rdata[17]} {fifo_s_axi_rdata[18]} {fifo_s_axi_rdata[19]} {fifo_s_axi_rdata[20]} {fifo_s_axi_rdata[21]} {fifo_s_axi_rdata[22]} {fifo_s_axi_rdata[23]} {fifo_s_axi_rdata[24]} {fifo_s_axi_rdata[25]} {fifo_s_axi_rdata[26]} {fifo_s_axi_rdata[27]} {fifo_s_axi_rdata[28]} {fifo_s_axi_rdata[29]} {fifo_s_axi_rdata[30]} {fifo_s_axi_rdata[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe7]
+set_property port_width 2 [get_debug_ports u_ila_0/probe7]
+connect_debug_port u_ila_0/probe7 [get_nets [list {fifo_s_axi_rresp[0]} {fifo_s_axi_rresp[1]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe8]
+set_property port_width 32 [get_debug_ports u_ila_0/probe8]
+connect_debug_port u_ila_0/probe8 [get_nets [list {fifo_s_axi_wdata[0]} {fifo_s_axi_wdata[1]} {fifo_s_axi_wdata[2]} {fifo_s_axi_wdata[3]} {fifo_s_axi_wdata[4]} {fifo_s_axi_wdata[5]} {fifo_s_axi_wdata[6]} {fifo_s_axi_wdata[7]} {fifo_s_axi_wdata[8]} {fifo_s_axi_wdata[9]} {fifo_s_axi_wdata[10]} {fifo_s_axi_wdata[11]} {fifo_s_axi_wdata[12]} {fifo_s_axi_wdata[13]} {fifo_s_axi_wdata[14]} {fifo_s_axi_wdata[15]} {fifo_s_axi_wdata[16]} {fifo_s_axi_wdata[17]} {fifo_s_axi_wdata[18]} {fifo_s_axi_wdata[19]} {fifo_s_axi_wdata[20]} {fifo_s_axi_wdata[21]} {fifo_s_axi_wdata[22]} {fifo_s_axi_wdata[23]} {fifo_s_axi_wdata[24]} {fifo_s_axi_wdata[25]} {fifo_s_axi_wdata[26]} {fifo_s_axi_wdata[27]} {fifo_s_axi_wdata[28]} {fifo_s_axi_wdata[29]} {fifo_s_axi_wdata[30]} {fifo_s_axi_wdata[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe9]
+set_property port_width 4 [get_debug_ports u_ila_0/probe9]
+connect_debug_port u_ila_0/probe9 [get_nets [list {fifo_s_axi_wstrb[0]} {fifo_s_axi_wstrb[1]} {fifo_s_axi_wstrb[2]} {fifo_s_axi_wstrb[3]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe10]
+set_property port_width 4 [get_debug_ports u_ila_0/probe10]
+connect_debug_port u_ila_0/probe10 [get_nets [list {mii_txd[0]} {mii_txd[1]} {mii_txd[2]} {mii_txd[3]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe11]
+set_property port_width 32 [get_debug_ports u_ila_0/probe11]
+connect_debug_port u_ila_0/probe11 [get_nets [list {m_axis_rxd_tdata[0]} {m_axis_rxd_tdata[1]} {m_axis_rxd_tdata[2]} {m_axis_rxd_tdata[3]} {m_axis_rxd_tdata[4]} {m_axis_rxd_tdata[5]} {m_axis_rxd_tdata[6]} {m_axis_rxd_tdata[7]} {m_axis_rxd_tdata[8]} {m_axis_rxd_tdata[9]} {m_axis_rxd_tdata[10]} {m_axis_rxd_tdata[11]} {m_axis_rxd_tdata[12]} {m_axis_rxd_tdata[13]} {m_axis_rxd_tdata[14]} {m_axis_rxd_tdata[15]} {m_axis_rxd_tdata[16]} {m_axis_rxd_tdata[17]} {m_axis_rxd_tdata[18]} {m_axis_rxd_tdata[19]} {m_axis_rxd_tdata[20]} {m_axis_rxd_tdata[21]} {m_axis_rxd_tdata[22]} {m_axis_rxd_tdata[23]} {m_axis_rxd_tdata[24]} {m_axis_rxd_tdata[25]} {m_axis_rxd_tdata[26]} {m_axis_rxd_tdata[27]} {m_axis_rxd_tdata[28]} {m_axis_rxd_tdata[29]} {m_axis_rxd_tdata[30]} {m_axis_rxd_tdata[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe12]
+set_property port_width 4 [get_debug_ports u_ila_0/probe12]
+connect_debug_port u_ila_0/probe12 [get_nets [list {m_axis_rxd_tkeep[0]} {m_axis_rxd_tkeep[1]} {m_axis_rxd_tkeep[2]} {m_axis_rxd_tkeep[3]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe13]
+set_property port_width 32 [get_debug_ports u_ila_0/probe13]
+connect_debug_port u_ila_0/probe13 [get_nets [list {s_axi_araddr[0]} {s_axi_araddr[1]} {s_axi_araddr[2]} {s_axi_araddr[3]} {s_axi_araddr[4]} {s_axi_araddr[5]} {s_axi_araddr[6]} {s_axi_araddr[7]} {s_axi_araddr[8]} {s_axi_araddr[9]} {s_axi_araddr[10]} {s_axi_araddr[11]} {s_axi_araddr[12]} {s_axi_araddr[13]} {s_axi_araddr[14]} {s_axi_araddr[15]} {s_axi_araddr[16]} {s_axi_araddr[17]} {s_axi_araddr[18]} {s_axi_araddr[19]} {s_axi_araddr[20]} {s_axi_araddr[21]} {s_axi_araddr[22]} {s_axi_araddr[23]} {s_axi_araddr[24]} {s_axi_araddr[25]} {s_axi_araddr[26]} {s_axi_araddr[27]} {s_axi_araddr[28]} {s_axi_araddr[29]} {s_axi_araddr[30]} {s_axi_araddr[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe14]
+set_property port_width 32 [get_debug_ports u_ila_0/probe14]
+connect_debug_port u_ila_0/probe14 [get_nets [list {s_axi_awaddr[0]} {s_axi_awaddr[1]} {s_axi_awaddr[2]} {s_axi_awaddr[3]} {s_axi_awaddr[4]} {s_axi_awaddr[5]} {s_axi_awaddr[6]} {s_axi_awaddr[7]} {s_axi_awaddr[8]} {s_axi_awaddr[9]} {s_axi_awaddr[10]} {s_axi_awaddr[11]} {s_axi_awaddr[12]} {s_axi_awaddr[13]} {s_axi_awaddr[14]} {s_axi_awaddr[15]} {s_axi_awaddr[16]} {s_axi_awaddr[17]} {s_axi_awaddr[18]} {s_axi_awaddr[19]} {s_axi_awaddr[20]} {s_axi_awaddr[21]} {s_axi_awaddr[22]} {s_axi_awaddr[23]} {s_axi_awaddr[24]} {s_axi_awaddr[25]} {s_axi_awaddr[26]} {s_axi_awaddr[27]} {s_axi_awaddr[28]} {s_axi_awaddr[29]} {s_axi_awaddr[30]} {s_axi_awaddr[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe15]
+set_property port_width 2 [get_debug_ports u_ila_0/probe15]
+connect_debug_port u_ila_0/probe15 [get_nets [list {s_axi_bresp[0]} {s_axi_bresp[1]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe16]
+set_property port_width 32 [get_debug_ports u_ila_0/probe16]
+connect_debug_port u_ila_0/probe16 [get_nets [list {s_axi_rdata[0]} {s_axi_rdata[1]} {s_axi_rdata[2]} {s_axi_rdata[3]} {s_axi_rdata[4]} {s_axi_rdata[5]} {s_axi_rdata[6]} {s_axi_rdata[7]} {s_axi_rdata[8]} {s_axi_rdata[9]} {s_axi_rdata[10]} {s_axi_rdata[11]} {s_axi_rdata[12]} {s_axi_rdata[13]} {s_axi_rdata[14]} {s_axi_rdata[15]} {s_axi_rdata[16]} {s_axi_rdata[17]} {s_axi_rdata[18]} {s_axi_rdata[19]} {s_axi_rdata[20]} {s_axi_rdata[21]} {s_axi_rdata[22]} {s_axi_rdata[23]} {s_axi_rdata[24]} {s_axi_rdata[25]} {s_axi_rdata[26]} {s_axi_rdata[27]} {s_axi_rdata[28]} {s_axi_rdata[29]} {s_axi_rdata[30]} {s_axi_rdata[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe17]
+set_property port_width 2 [get_debug_ports u_ila_0/probe17]
+connect_debug_port u_ila_0/probe17 [get_nets [list {s_axi_rresp[0]} {s_axi_rresp[1]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe18]
+set_property port_width 32 [get_debug_ports u_ila_0/probe18]
+connect_debug_port u_ila_0/probe18 [get_nets [list {s_axi_wdata[0]} {s_axi_wdata[1]} {s_axi_wdata[2]} {s_axi_wdata[3]} {s_axi_wdata[4]} {s_axi_wdata[5]} {s_axi_wdata[6]} {s_axi_wdata[7]} {s_axi_wdata[8]} {s_axi_wdata[9]} {s_axi_wdata[10]} {s_axi_wdata[11]} {s_axi_wdata[12]} {s_axi_wdata[13]} {s_axi_wdata[14]} {s_axi_wdata[15]} {s_axi_wdata[16]} {s_axi_wdata[17]} {s_axi_wdata[18]} {s_axi_wdata[19]} {s_axi_wdata[20]} {s_axi_wdata[21]} {s_axi_wdata[22]} {s_axi_wdata[23]} {s_axi_wdata[24]} {s_axi_wdata[25]} {s_axi_wdata[26]} {s_axi_wdata[27]} {s_axi_wdata[28]} {s_axi_wdata[29]} {s_axi_wdata[30]} {s_axi_wdata[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe19]
+set_property port_width 4 [get_debug_ports u_ila_0/probe19]
+connect_debug_port u_ila_0/probe19 [get_nets [list {s_axi_wstrb[0]} {s_axi_wstrb[1]} {s_axi_wstrb[2]} {s_axi_wstrb[3]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe20]
+set_property port_width 32 [get_debug_ports u_ila_0/probe20]
+connect_debug_port u_ila_0/probe20 [get_nets [list {s_axis_txc_tdata[0]} {s_axis_txc_tdata[1]} {s_axis_txc_tdata[2]} {s_axis_txc_tdata[3]} {s_axis_txc_tdata[4]} {s_axis_txc_tdata[5]} {s_axis_txc_tdata[6]} {s_axis_txc_tdata[7]} {s_axis_txc_tdata[8]} {s_axis_txc_tdata[9]} {s_axis_txc_tdata[10]} {s_axis_txc_tdata[11]} {s_axis_txc_tdata[12]} {s_axis_txc_tdata[13]} {s_axis_txc_tdata[14]} {s_axis_txc_tdata[15]} {s_axis_txc_tdata[16]} {s_axis_txc_tdata[17]} {s_axis_txc_tdata[18]} {s_axis_txc_tdata[19]} {s_axis_txc_tdata[20]} {s_axis_txc_tdata[21]} {s_axis_txc_tdata[22]} {s_axis_txc_tdata[23]} {s_axis_txc_tdata[24]} {s_axis_txc_tdata[25]} {s_axis_txc_tdata[26]} {s_axis_txc_tdata[27]} {s_axis_txc_tdata[28]} {s_axis_txc_tdata[29]} {s_axis_txc_tdata[30]} {s_axis_txc_tdata[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe21]
+set_property port_width 32 [get_debug_ports u_ila_0/probe21]
+connect_debug_port u_ila_0/probe21 [get_nets [list {s_axis_txd_tdata[0]} {s_axis_txd_tdata[1]} {s_axis_txd_tdata[2]} {s_axis_txd_tdata[3]} {s_axis_txd_tdata[4]} {s_axis_txd_tdata[5]} {s_axis_txd_tdata[6]} {s_axis_txd_tdata[7]} {s_axis_txd_tdata[8]} {s_axis_txd_tdata[9]} {s_axis_txd_tdata[10]} {s_axis_txd_tdata[11]} {s_axis_txd_tdata[12]} {s_axis_txd_tdata[13]} {s_axis_txd_tdata[14]} {s_axis_txd_tdata[15]} {s_axis_txd_tdata[16]} {s_axis_txd_tdata[17]} {s_axis_txd_tdata[18]} {s_axis_txd_tdata[19]} {s_axis_txd_tdata[20]} {s_axis_txd_tdata[21]} {s_axis_txd_tdata[22]} {s_axis_txd_tdata[23]} {s_axis_txd_tdata[24]} {s_axis_txd_tdata[25]} {s_axis_txd_tdata[26]} {s_axis_txd_tdata[27]} {s_axis_txd_tdata[28]} {s_axis_txd_tdata[29]} {s_axis_txd_tdata[30]} {s_axis_txd_tdata[31]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe22]
+set_property port_width 4 [get_debug_ports u_ila_0/probe22]
+connect_debug_port u_ila_0/probe22 [get_nets [list {s_axis_txd_tkeep[0]} {s_axis_txd_tkeep[1]} {s_axis_txd_tkeep[2]} {s_axis_txd_tkeep[3]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe23]
+set_property port_width 4 [get_debug_ports u_ila_0/probe23]
+connect_debug_port u_ila_0/probe23 [get_nets [list {s_axis_txc_tkeep[0]} {s_axis_txc_tkeep[1]} {s_axis_txc_tkeep[2]} {s_axis_txc_tkeep[3]}]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe24]
+set_property port_width 1 [get_debug_ports u_ila_0/probe24]
+connect_debug_port u_ila_0/probe24 [get_nets [list eth_crsdv_IBUF]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe25]
+set_property port_width 1 [get_debug_ports u_ila_0/probe25]
+connect_debug_port u_ila_0/probe25 [get_nets [list eth_mdc_OBUF]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe26]
+set_property port_width 1 [get_debug_ports u_ila_0/probe26]
+connect_debug_port u_ila_0/probe26 [get_nets [list eth_refclk_OBUF]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe27]
+set_property port_width 1 [get_debug_ports u_ila_0/probe27]
+connect_debug_port u_ila_0/probe27 [get_nets [list eth_rstn_OBUF]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe28]
+set_property port_width 1 [get_debug_ports u_ila_0/probe28]
+connect_debug_port u_ila_0/probe28 [get_nets [list eth_rxerr_IBUF]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe29]
+set_property port_width 1 [get_debug_ports u_ila_0/probe29]
+connect_debug_port u_ila_0/probe29 [get_nets [list eth_txen_OBUF]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe30]
+set_property port_width 1 [get_debug_ports u_ila_0/probe30]
+connect_debug_port u_ila_0/probe30 [get_nets [list fifo_s_axi_arready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe31]
+set_property port_width 1 [get_debug_ports u_ila_0/probe31]
+connect_debug_port u_ila_0/probe31 [get_nets [list fifo_s_axi_arvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe32]
+set_property port_width 1 [get_debug_ports u_ila_0/probe32]
+connect_debug_port u_ila_0/probe32 [get_nets [list fifo_s_axi_awready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe33]
+set_property port_width 1 [get_debug_ports u_ila_0/probe33]
+connect_debug_port u_ila_0/probe33 [get_nets [list fifo_s_axi_awvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe34]
+set_property port_width 1 [get_debug_ports u_ila_0/probe34]
+connect_debug_port u_ila_0/probe34 [get_nets [list fifo_s_axi_bready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe35]
+set_property port_width 1 [get_debug_ports u_ila_0/probe35]
+connect_debug_port u_ila_0/probe35 [get_nets [list fifo_s_axi_bvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe36]
+set_property port_width 1 [get_debug_ports u_ila_0/probe36]
+connect_debug_port u_ila_0/probe36 [get_nets [list fifo_s_axi_rready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe37]
+set_property port_width 1 [get_debug_ports u_ila_0/probe37]
+connect_debug_port u_ila_0/probe37 [get_nets [list fifo_s_axi_rvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe38]
+set_property port_width 1 [get_debug_ports u_ila_0/probe38]
+connect_debug_port u_ila_0/probe38 [get_nets [list fifo_s_axi_wready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe39]
+set_property port_width 1 [get_debug_ports u_ila_0/probe39]
+connect_debug_port u_ila_0/probe39 [get_nets [list fifo_s_axi_wvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe40]
+set_property port_width 1 [get_debug_ports u_ila_0/probe40]
+connect_debug_port u_ila_0/probe40 [get_nets [list m_axis_rxd_tlast]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe41]
+set_property port_width 1 [get_debug_ports u_ila_0/probe41]
+connect_debug_port u_ila_0/probe41 [get_nets [list m_axis_rxd_tready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe42]
+set_property port_width 1 [get_debug_ports u_ila_0/probe42]
+connect_debug_port u_ila_0/probe42 [get_nets [list m_axis_rxd_tvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe43]
+set_property port_width 1 [get_debug_ports u_ila_0/probe43]
+connect_debug_port u_ila_0/probe43 [get_nets [list s_axi_arready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe44]
+set_property port_width 1 [get_debug_ports u_ila_0/probe44]
+connect_debug_port u_ila_0/probe44 [get_nets [list s_axi_arvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe45]
+set_property port_width 1 [get_debug_ports u_ila_0/probe45]
+connect_debug_port u_ila_0/probe45 [get_nets [list s_axi_awready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe46]
+set_property port_width 1 [get_debug_ports u_ila_0/probe46]
+connect_debug_port u_ila_0/probe46 [get_nets [list s_axi_awvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe47]
+set_property port_width 1 [get_debug_ports u_ila_0/probe47]
+connect_debug_port u_ila_0/probe47 [get_nets [list s_axi_bready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe48]
+set_property port_width 1 [get_debug_ports u_ila_0/probe48]
+connect_debug_port u_ila_0/probe48 [get_nets [list s_axi_bvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe49]
+set_property port_width 1 [get_debug_ports u_ila_0/probe49]
+connect_debug_port u_ila_0/probe49 [get_nets [list s_axi_rready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe50]
+set_property port_width 1 [get_debug_ports u_ila_0/probe50]
+connect_debug_port u_ila_0/probe50 [get_nets [list s_axi_rvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe51]
+set_property port_width 1 [get_debug_ports u_ila_0/probe51]
+connect_debug_port u_ila_0/probe51 [get_nets [list s_axi_wready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe52]
+set_property port_width 1 [get_debug_ports u_ila_0/probe52]
+connect_debug_port u_ila_0/probe52 [get_nets [list s_axi_wvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe53]
+set_property port_width 1 [get_debug_ports u_ila_0/probe53]
+connect_debug_port u_ila_0/probe53 [get_nets [list s_axis_txc_tlast]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe54]
+set_property port_width 1 [get_debug_ports u_ila_0/probe54]
+connect_debug_port u_ila_0/probe54 [get_nets [list s_axis_txc_tready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe55]
+set_property port_width 1 [get_debug_ports u_ila_0/probe55]
+connect_debug_port u_ila_0/probe55 [get_nets [list s_axis_txc_tvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe56]
+set_property port_width 1 [get_debug_ports u_ila_0/probe56]
+connect_debug_port u_ila_0/probe56 [get_nets [list s_axis_txd_tlast]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe57]
+set_property port_width 1 [get_debug_ports u_ila_0/probe57]
+connect_debug_port u_ila_0/probe57 [get_nets [list s_axis_txd_tready]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe58]
+set_property port_width 1 [get_debug_ports u_ila_0/probe58]
+connect_debug_port u_ila_0/probe58 [get_nets [list s_axis_txd_tvalid]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe59]
+set_property port_width 1 [get_debug_ports u_ila_0/probe59]
+connect_debug_port u_ila_0/probe59 [get_nets [list mii_rx_clk]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe60]
+set_property port_width 1 [get_debug_ports u_ila_0/probe60]
+connect_debug_port u_ila_0/probe60 [get_nets [list mii_rx_dv]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe61]
+set_property port_width 1 [get_debug_ports u_ila_0/probe61]
+connect_debug_port u_ila_0/probe61 [get_nets [list mii_rx_er]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe62]
+set_property port_width 1 [get_debug_ports u_ila_0/probe62]
+connect_debug_port u_ila_0/probe62 [get_nets [list mii_tx_clk]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe63]
+set_property port_width 1 [get_debug_ports u_ila_0/probe63]
+connect_debug_port u_ila_0/probe63 [get_nets [list mii_tx_en]]
+create_debug_port u_ila_0 probe
+set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe64]
+set_property port_width 1 [get_debug_ports u_ila_0/probe64]
+connect_debug_port u_ila_0/probe64 [get_nets [list mii_tx_er]]
+set_property C_CLK_INPUT_FREQ_HZ 300000000 [get_debug_cores dbg_hub]
+set_property C_ENABLE_CLK_DIVIDER false [get_debug_cores dbg_hub]
+set_property C_USER_SCAN_CHAIN 1 [get_debug_cores dbg_hub]
+connect_debug_port dbg_hub/clk [get_nets sys_clk]

--- a/external/extra_cores/boards/nexys4ddr/nexys4ddr.core
+++ b/external/extra_cores/boards/nexys4ddr/nexys4ddr.core
@@ -4,6 +4,7 @@ name = wallento:boards:nexys4ddr
 depend =
   wallento:boards:nexys4ddr-ddr
   wallento:boards:nexys4ddr-clk_sys
+  wallento:boards:nexys4ddr-clk_eth
 
 [fileset rtl_files]
 files =

--- a/external/extra_cores/boards/nexys4ddr/rtl/verilog/nexys4ddr.sv
+++ b/external/extra_cores/boards/nexys4ddr/rtl/verilog/nexys4ddr.sv
@@ -61,6 +61,10 @@ module nexys4ddr
    // System Interface
    output                sys_clk,
    output                sys_rst,
+   
+   output                clk_50mhz,
+   output                clk_50mhz_45deg,
+   output                clk_125mhz,
 
    input [3:0]           ddr_awid,
    input [27:0]          ddr_awaddr,
@@ -138,6 +142,18 @@ module nexys4ddr
         .locked      (clk_ddr_locked),
         .reset       (rst)
         );
+     
+  wire clk_eth_locked;
+
+  clk_gen_eth
+     u_clk_gen_eth
+     (.clk_ddr_sys        (clk_ddr_sys),
+        .clk_50mhz        (clk_50mhz),
+        .clk_50mhz_45deg  (clk_50mhz_45deg),
+        .clk_125mhz       (clk_125mhz),
+        .locked           (clk_eth_locked),
+        .reset            (rst)
+     );
 
 /*   clk_gen_sys
      u_clk_gen_sys
@@ -189,7 +205,7 @@ module nexys4ddr
         .init_calib_complete            (ddr_calib_done),
         .sys_clk_i                      (clk_ddr_sys),
 //        .clk_ref_i                      (clk_ddr_ref),
-        .sys_rst                        (clk_ddr_locked | rst),
+        .sys_rst                        (clk_eth_locked | clk_ddr_locked | rst),
 
         // Application interface ports
         .ui_clk                         (mig_ui_clk),


### PR DESCRIPTION
WIP pull request for issue #90

To test out the changes, first build optimsoc using 
```sh
cd ~/src/optimsoc
./tools/build.py --without-examples-fpga --without-examples-sim --link-hw --without-docs
```

Then build the example project using
```sh
fusesoc --cores-root=~/src/optimsoc/examples build optimsoc:examples:compute_tile_ethernet_nexys4ddr
```

Annika, could you continue from here? Things to be done:
- [ ] Restructure code (see discussion below)
- [ ] Fix coding style: three spaces, no trailing spaces (let the editor remove all those on saving), etc.

On the code structure: We should rearrange the modules a bit to make them better reusable.

```

 +----------------+                   +-------------------+     +--------------------+
 |                |                   |                   | MII |                    |
 | PHY (external) | RMII/MII/whatever | board abstraction |     | na_ethernet_xilinx | Wishbone
 |                |                   |                   | MDI |                    | slave if
 +----------------+                   +-------------------+     +--------------------+
```


- Put the board-specific (i.e. everything required only for the Nexys 4 DDR board) into the board support package (in `external/extra_cores/boards/nexys4ddr`). That's probably the RMII2MII converter as well as the clock generation.
- Create a new folder/module in `src/soc/hw` containing an Ethernet "network card". It gets as input the MII and MDIO signals from the board abstraction, and has on the output side a Wishbone slave interface (or two, one for RX/TX and one for control). This encapsulates the AXI Ethernet Subsystem and the AXI Stream FIFOs. By abstracting at the MII boundary, this part should be reusable for other boards.
- In the compute_tile_dm module, instantiate the network adapter module.
