### PR TITLE
fixed QtXmlPatterns dependency for gui

### DIFF
--- a/src/host/optimsocgui/CMakeLists.txt
+++ b/src/host/optimsocgui/CMakeLists.txt
@@ -39,7 +39,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/)
 # check for Qt
 set(QT_MT_REQUIRED TRUE)
 set(QT_MIN_VERSION "4.8.0")
-find_package(Qt4 REQUIRED QtCore QtGui QtXml QtWebkit)
+find_package(Qt4 REQUIRED QtCore QtGui QtXml QtXmlPatterns QtWebkit)
 
 include(${QT_USE_FILE})
 


### PR DESCRIPTION
I get following error while building optimsocgui on Debian:

/usr/bin/ld: CMakeFiles/optimsocgui.dir/optimsocsystem.cpp.o: undefined reference to symbol '_ZN19QXmlSchemaValidatorC1ERK10QXmlSchema'
//usr/lib/x86_64-linux-gnu/libQtXmlPatterns.so.4: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
src/CMakeFiles/optimsocgui.dir/build.make:1944: recipe for target 'src/optimsocgui' failed
make[2]: *** [src/optimsocgui] Error 1
CMakeFiles/Makefile2:117: recipe for target 'src/CMakeFiles/optimsocgui.dir/all' failed
make[1]: *** [src/CMakeFiles/optimsocgui.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2

This issue was solved by changes in this commit.