### PR TITLE
Add FIFO primitives

### DIFF
--- a/src/soc/hw/fifo/fifo_sync_fwft.core
+++ b/src/soc/hw/fifo/fifo_sync_fwft.core
@@ -1,0 +1,12 @@
+CAPI=1
+[main]
+description = "Synchronous First-Word Fall-Through (FWFT) FIFO"
+name = optimsoc:fifo:fifo_sync_fwft
+depend = optimsoc:fifo:fifo_sync_standard
+
+[fileset src_files]
+file_type = systemVerilogSource
+usage = sim synth
+files =
+  verilog/fifo_sync_fwft.sv
+

--- a/src/soc/hw/fifo/fifo_sync_noc.core
+++ b/src/soc/hw/fifo/fifo_sync_noc.core
@@ -1,0 +1,12 @@
+CAPI=1
+[main]
+description = "Synchrnous FIFO with NoC port naming"
+name = optimsoc:fifo:fifo_sync_noc
+depend = optimsoc:fifo:fifo_sync_fwft
+
+[fileset src_files]
+file_type = systemVerilogSource
+usage = sim synth
+files =
+  verilog/fifo_sync_noc.sv
+

--- a/src/soc/hw/fifo/fifo_sync_standard.core
+++ b/src/soc/hw/fifo/fifo_sync_standard.core
@@ -1,0 +1,11 @@
+CAPI=1
+[main]
+description = "Synchronous Standard FIFO"
+name = optimsoc:fifo:fifo_sync_standard
+
+[fileset src_files]
+file_type = systemVerilogSource
+usage = sim synth
+files =
+  verilog/fifo_sync_standard.sv
+

--- a/src/soc/hw/fifo/test/fifo_test_common.py
+++ b/src/soc/hw/fifo/test/fifo_test_common.py
@@ -1,0 +1,142 @@
+"""
+Common functionality to test FIFOs
+"""
+
+import random
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, FallingEdge
+from cocotb.result import TestFailure
+
+# Mirroring expected contents of the FIFO
+_fifo_data = []
+
+@cocotb.coroutine
+def write_fifo(dut, max_delay=5, write_items=10000, write_random_data=False):
+    """
+    Write to a FIFO
+    
+    Before writing wait between 0 and max_delay cycles.
+    """
+    fifo_wrcnt = 0
+    while True:
+        # insert random wait before the next write
+        wr_delay = random.randint(0, max_delay)
+        dut._log.debug("WRITE: Wait for %d clock cycles" % (wr_delay))
+        for _ in range(wr_delay):
+            yield RisingEdge(dut.clk)
+
+        # make sure that the full signal is stable before checking for it
+        yield FallingEdge(dut.clk)
+
+        if dut.full.value:
+            dut._log.debug("WRITE: FIFO full, not writing")
+        else:
+            # generate and write data, keep track of it for checking
+            if write_random_data:
+                data = random.getrandbits(dut.WIDTH.value.integer)
+            else:
+                data = fifo_wrcnt % (2 ** dut.WIDTH.value.integer)
+            dut.din <= data
+            _fifo_data.append(data)
+
+            dut.wr_en <= 1
+            yield RisingEdge(dut.clk)
+            dut.wr_en <= 0
+
+            fifo_wrcnt += 1
+            dut._log.debug("WRITE: Wrote word %d to FIFO, value 0x%x" % (fifo_wrcnt, data))
+
+        if fifo_wrcnt >= write_items:
+            return
+
+@cocotb.coroutine
+def read_fifo_standard(dut, max_delay=5, read_items=10000):
+    """
+    Read from a FIFO with standard read semantics and validate the reads
+    
+    Before the read starts a delay between 0 and max_delay cycles is
+    waited. No read is attempted is the FIFO signals it's empty.
+    """
+    fifo_rdcnt = 0
+    while True:
+        # insert random wait before the next read
+        rd_delay = random.randint(0, max_delay)
+        dut._log.debug("READ: Wait for %d clock cycles" % (rd_delay))
+        for _ in range(rd_delay):
+            yield RisingEdge(dut.clk)
+
+        if dut.empty.value:
+            dut._log.debug("READ: FIFO empty, not reading")
+        else:
+            # send read request
+            dut.rd_en <= 1
+            fifo_rdcnt += 1
+
+            yield RisingEdge(dut.clk)
+
+            # output is delayed by one cycle
+            # lower read request signal
+            dut.rd_en <= 0
+            yield RisingEdge(dut.clk)
+
+            data_read = dut.dout.value.integer
+            dut._log.debug("READ: Got 0x%x in read %d" % (data_read, fifo_rdcnt))
+
+            data_expected = _fifo_data.pop(0)
+            if data_read != data_expected:
+                raise TestFailure("READ: Expected 0x%x, got 0x%x at read %d" %
+                                  (data_expected, data_read, fifo_rdcnt))
+
+        # done
+        if fifo_rdcnt >= read_items:
+            return
+
+@cocotb.coroutine
+def read_fifo_fwft(dut, max_delay=5, read_items=10000):
+    """
+    Read from a FIFO with FWFT read semantics and validate the reads
+    
+    Before the read starts a delay between 0 and max_delay cycles is
+    waited. No read is attempted is the FIFO signals it's empty.
+    """
+    fifo_rdcnt = 0
+    while True:
+        # determine wait cycles before next read
+        rd_delay = random.randint(0, max_delay)
+        dut._log.debug("READ: Wait for %d clock cycles" % (rd_delay))
+
+        # wait until the next read operation
+        if rd_delay != 0:
+            # deactivate read request if we have wait cycles
+            dut.rd_en <= 0
+
+            for _ in range(rd_delay):
+                yield RisingEdge(dut.clk)
+
+        # wait until all signals are stable in this cycle before we check
+        # its value
+        yield FallingEdge(dut.clk)
+
+        if dut.empty.value:
+            dut._log.debug("READ: FIFO empty, not reading")
+        else:
+            # get current data word
+            data_read = dut.dout.value.integer
+            fifo_rdcnt += 1
+            dut._log.debug("READ: Got 0x%x in read %d" % (data_read, fifo_rdcnt))
+
+            # acknowledge read
+            dut.rd_en <= 1
+
+            # check read data word
+            data_expected = _fifo_data.pop(0)
+            if data_read != data_expected:
+                raise TestFailure("READ: Expected 0x%x, got 0x%x at read %d" %
+                                  (data_expected, data_read, fifo_rdcnt))
+
+        # done with this cycle, wait for the next one
+        yield RisingEdge(dut.clk)
+
+        if fifo_rdcnt >= read_items:
+            return

--- a/src/soc/hw/fifo/test/test_fifo_sync_fwft.manifest.yaml
+++ b/src/soc/hw/fifo/test/test_fifo_sync_fwft.manifest.yaml
@@ -1,0 +1,14 @@
+module: test_fifo_sync_fwft
+
+sources:
+  - ../verilog/fifo_sync_fwft.sv
+  - ../verilog/fifo_sync_standard.sv
+
+toplevel: fifo_sync_fwft
+
+simulators:
+  - vcs
+
+parameters:
+    WIDTH: 16
+    DEPTH: 32

--- a/src/soc/hw/fifo/test/test_fifo_sync_fwft.py
+++ b/src/soc/hw/fifo/test/test_fifo_sync_fwft.py
@@ -1,0 +1,51 @@
+"""
+Test the module fifo_sync_fwft, a synchronous first-word-fall-through 
+FIFO
+"""
+
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, FallingEdge
+from cocotb.result import TestFailure
+
+from fifo_test_common import read_fifo_fwft, write_fifo
+    
+
+@cocotb.test()
+def test_fifo_sync_fwft(dut):
+    """
+    Test the module fifo_sync_fwft, a synchronous first-word-fall-through 
+    FIFO
+    """
+
+    # Read the parameters back from the DUT to set up our model
+    width = dut.WIDTH.value.integer  # [bit]
+    depth = dut.DEPTH.value.integer  # [entries]
+    dut._log.info("%d bit wide FIFO with %d entries." % (width, depth))
+
+    # setup clock
+    cocotb.fork(Clock(dut.clk, 1000).start())
+    
+    # reset
+    dut._log.info("Resetting DUT")
+    dut.rst <= 1
+
+    dut.din <= 0
+    dut.wr_en <= 0
+    dut.rd_en <= 0
+
+    for _ in range(2):
+        yield RisingEdge(dut.clk)
+    dut.rst <= 0
+
+    # start read and write processes
+    write_thread = cocotb.fork(write_fifo(dut))
+    read_thread = cocotb.fork(read_fifo_fwft(dut))
+
+    # wait for read/write to finish. Read only finishes if all required data
+    # has been obtained, i.e. it implicitly waits for write as well.
+    yield read_thread.join()
+
+    dut._log.info("All tests done")

--- a/src/soc/hw/fifo/test/test_fifo_sync_standard.manifest.yaml
+++ b/src/soc/hw/fifo/test/test_fifo_sync_standard.manifest.yaml
@@ -1,0 +1,13 @@
+module: test_fifo_sync_standard
+
+sources:
+  - ../verilog/fifo_sync_standard.sv
+
+toplevel: fifo_sync_standard
+
+simulators:
+  - vcs
+
+parameters:
+    WIDTH: 16
+    DEPTH: 32

--- a/src/soc/hw/fifo/test/test_fifo_sync_standard.py
+++ b/src/soc/hw/fifo/test/test_fifo_sync_standard.py
@@ -1,0 +1,50 @@
+"""
+Test the module fifo_sync_standard, a synchronous FIFO with standard
+read characteristics
+"""
+
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, FallingEdge
+from cocotb.result import TestFailure
+
+from fifo_test_common import read_fifo_standard, write_fifo
+    
+@cocotb.test()
+def test_fifo_sync_standard(dut):
+    """
+    Test the module fifo_sync, a synchronous FIFO with standard read
+    characteristics
+    """
+
+    # Read the parameters back from the DUT to set up our model
+    width = dut.WIDTH.value.integer  # [bit]
+    depth = dut.DEPTH.value.integer  # [entries]
+    dut._log.info("%d bit wide FIFO with %d entries." % (width, depth))
+
+    # setup clock
+    cocotb.fork(Clock(dut.clk, 1000).start())
+
+    # reset
+    dut._log.debug("Resetting DUT")
+    dut.rst <= 1
+
+    dut.din <= 0
+    dut.wr_en <= 0
+    dut.rd_en <= 0
+
+    for _ in range(2):
+        yield RisingEdge(dut.clk)
+    dut.rst <= 0
+
+    # start read and write processes
+    write_thread = cocotb.fork(write_fifo(dut))
+    read_thread = cocotb.fork(read_fifo_standard(dut))
+
+    # wait for read/write to finish. Read only finishes if all required data
+    # has been obtained, i.e. it implicitly waits for write as well.
+    yield read_thread.join()
+
+    dut._log.info("All tests done")

--- a/src/soc/hw/fifo/verilog/fifo_sync_fwft.sv
+++ b/src/soc/hw/fifo/verilog/fifo_sync_fwft.sv
@@ -1,0 +1,112 @@
+/* Copyright (c) 2017 by the author(s)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * =============================================================================
+ *
+ * Synchronous First-Word Fall-Through (FWFT) FIFO
+ *
+ * This FIFO implementation wraps the FIFO with standard read characteristics
+ * to have first-word fall-through read characteristics.
+ *
+ * Author(s):
+ *   Philipp Wagner <philipp.wagner@tum.de>
+ */
+module fifo_sync_fwft #(
+   parameter WIDTH = 8,
+   parameter DEPTH = 32,
+   parameter PROG_FULL = (DEPTH / 2)
+)(
+    input                    clk,
+    input                    rst,
+
+    input [(WIDTH-1):0]      din,
+    input                    wr_en,
+    output                   full,
+    output                   prog_full,
+
+    output reg [(WIDTH-1):0] dout,
+    input                    rd_en,
+    output                   empty
+);
+
+   reg                       fifo_valid, middle_valid, dout_valid;
+   reg [(WIDTH-1):0]         middle_dout;
+
+   wire [(WIDTH-1):0]        fifo_dout;
+   wire                      fifo_empty, fifo_rd_en;
+   wire                      will_update_middle, will_update_dout;
+
+   // synchronous FIFO with standard (non-FWFT) read characteristics
+   fifo_sync_standard
+      #(.WIDTH(WIDTH),
+        .DEPTH(DEPTH),
+        .PROG_FULL(PROG_FULL))
+      u_fifo (
+         .rst(rst),
+         .clk(clk),
+         .rd_en(fifo_rd_en),
+         .dout(fifo_dout),
+         .empty(fifo_empty),
+         .wr_en(wr_en),
+         .din(din),
+         .full(full),
+         .prog_full(prog_full)
+      );
+
+   // create FWFT FIFO out of non-FWFT FIFO
+   // public domain code from Eli Billauer
+   // see http://www.billauer.co.il/reg_fifo.html
+   assign will_update_middle = fifo_valid && (middle_valid == will_update_dout);
+   assign will_update_dout = (middle_valid || fifo_valid) && (rd_en || !dout_valid);
+   assign fifo_rd_en = (!fifo_empty) && !(middle_valid && dout_valid && fifo_valid);
+   assign empty = !dout_valid;
+
+   always_ff @(posedge clk) begin
+      if (rst) begin
+         fifo_valid <= 0;
+         middle_valid <= 0;
+         dout_valid <= 0;
+         dout <= 0;
+         middle_dout <= 0;
+      end else begin
+         if (will_update_middle)
+            middle_dout <= fifo_dout;
+
+         if (will_update_dout)
+            dout <= middle_valid ? middle_dout : fifo_dout;
+
+         if (fifo_rd_en)
+            fifo_valid <= 1;
+         else if (will_update_middle || will_update_dout)
+            fifo_valid <= 0;
+
+         if (will_update_middle)
+            middle_valid <= 1;
+         else if (will_update_dout)
+            middle_valid <= 0;
+
+         if (will_update_dout)
+            dout_valid <= 1;
+         else if (rd_en)
+            dout_valid <= 0;
+      end
+   end
+
+endmodule

--- a/src/soc/hw/fifo/verilog/fifo_sync_noc.sv
+++ b/src/soc/hw/fifo/verilog/fifo_sync_noc.sv
@@ -1,0 +1,87 @@
+/* Copyright (c) 2017 by the author(s)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * =============================================================================
+ *
+ * Synchronous FWFT FIFO with NoC port naming
+ *
+ * In the NoC, we use slightly different signal naming than in regular FIFOs.
+ *
+ * Author(s):
+ *   Philipp Wagner <philipp.wagner@tum.de>
+ */
+// synchronous FWFT FIFO with NoC naming (nothing else changed)
+module fifo_sync_noc #(
+   parameter WIDTH = 34,
+   parameter DEPTH = 16
+)(
+   input clk,
+   input rst,
+
+   // FIFO input side
+   input  [WIDTH-1:0] in_flit,
+   input  in_valid,
+   output in_ready,
+
+   // FIFO output side
+   output [WIDTH-1:0] out_flit,
+   output out_valid,
+   input  out_ready
+);
+
+
+   wire [(WIDTH-1):0]  din;
+   wire                wr_en;
+   wire                full;
+
+   wire [(WIDTH-1):0]  dout;
+   wire                rd_en;
+   wire                empty;
+
+   // Synchronous FWFT FIFO
+   fifo_sync_fwft
+      #(
+         .WIDTH(WIDTH),
+         .DEPTH(DEPTH)
+      )
+      u_fifo (
+         .clk(clk),
+         .rst(rst),
+
+         .din(din),
+         .wr_en(wr_en),
+         .full(full),
+         .prog_full(), // unused
+
+         .dout(dout),
+         .rd_en(rd_en),
+         .empty(empty)
+      );
+
+   // map wire names from NoC naming to normal FIFO naming
+   assign din = in_flit;
+   assign wr_en = in_valid;
+   assign in_ready = ~full;
+
+   assign out_flit = dout;
+   assign out_valid = ~empty;
+   assign rd_en = out_ready;
+
+endmodule

--- a/src/soc/hw/fifo/verilog/fifo_sync_standard.sv
+++ b/src/soc/hw/fifo/verilog/fifo_sync_standard.sv
@@ -1,0 +1,101 @@
+/* Copyright (c) 2017 by the author(s)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * =============================================================================
+ *
+ * Synchronous Standard FIFO
+ *
+ * The memory block in this FIFO is following the "RAM HDL Coding Guidelines"
+ * of Xilinx (UG901) to enable placing the FIFO memory into block ram during
+ * synthesis.
+ *
+ * Author(s):
+ *   Philipp Wagner <philipp.wagner@tum.de>
+ */
+module fifo_sync_standard #(
+   parameter WIDTH = 8,
+   parameter DEPTH = 32,
+   parameter PROG_FULL = DEPTH / 2
+)(
+   input                     clk,
+   input                     rst,
+
+   input [(WIDTH-1):0]       din,
+   input                     wr_en,
+   output                    full,
+   output                    prog_full,
+
+   output reg [(WIDTH-1):0]  dout,
+   input                     rd_en,
+   output                    empty
+);
+
+   localparam AW = $clog2(DEPTH); // rd_count width
+
+   reg [AW-1:0] wr_addr;
+   reg [AW-1:0] rd_addr;
+   wire         fifo_read;
+   wire         fifo_write;
+   reg [AW-1:0] rd_count;
+
+   // generate control signals
+   assign empty       = (rd_count[AW-1:0] == 0);
+   assign prog_full   = (rd_count[AW-1:0] >= PROG_FULL);
+   assign full        = (rd_count[AW-1:0] == (DEPTH-1));
+   assign fifo_read   = rd_en & ~empty;
+   assign fifo_write  = wr_en & ~full;
+
+   // address logic
+   always_ff @(posedge clk) begin
+      if (rst) begin
+         wr_addr[AW-1:0]   <= 'd0;
+         rd_addr[AW-1:0]   <= 'b0;
+         rd_count[AW-1:0]  <= 'b0;
+      end else begin
+         if (fifo_write & fifo_read) begin
+            wr_addr[AW-1:0] <= wr_addr[AW-1:0] + 'd1;
+            rd_addr[AW-1:0] <= rd_addr[AW-1:0] + 'd1;
+         end else if (fifo_write) begin
+            wr_addr[AW-1:0] <= wr_addr[AW-1:0]  + 'd1;
+            rd_count[AW-1:0]<= rd_count[AW-1:0] + 'd1;
+         end else if (fifo_read) begin
+            rd_addr[AW-1:0] <= rd_addr[AW-1:0]  + 'd1;
+            rd_count[AW-1:0]<= rd_count[AW-1:0] - 'd1;
+         end
+      end
+   end
+
+   // generic dual-port, single clock memory
+   reg [WIDTH-1:0] ram [DEPTH-1:0];
+
+   // write
+   always_ff @(posedge clk) begin
+      if (fifo_write) begin
+         ram[wr_addr] <= din;
+      end
+   end
+
+   // read
+   always_ff @(posedge clk) begin
+      if (fifo_read) begin
+         dout <= ram[rd_addr];
+      end
+   end
+endmodule


### PR DESCRIPTION
Add two (and half) FIFOs:
- A standard fifo with one cycle read latency
- A first-word fall through FIFO (no read latency)
- A first-word fall through FIFO with changed signal naming, following
  the typical signal names we use for NoC connections (valid/ready).

The FIFO has been design follwing the Xilinx user guide rules for
inferrence into block ram.

For all FIFOs cocotb-based tests ensure their functioning.