### PR TITLE
Work around broken pip 10 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update
 RUN ./tools/install-build-deps.sh
 
 # Python dependencies
-RUN pip3 install --upgrade pip && pip3 install pytest fusesoc
+RUN pip3 install pytest fusesoc
 
 # target/installation directory
 RUN mkdir -p /opt/optimsoc


### PR DESCRIPTION
In recent CI runs we get:

Installing collected packages: pip
  Found existing installation: pip 8.1.1
    Not uninstalling pip at /usr/lib/python3/dist-packages, outside
environment /usr
Successfully installed pip-10.0.0
Traceback (most recent call last):
  File "/usr/bin/pip3", line 9, in <module>
    from pip import main
ImportError: cannot import name 'main'
The command '/bin/sh -c pip3 install --upgrade pip && pip3 install
pytest fusesoc' returned a non-zero code: 1

Also discussed at https://github.com/pypa/pip/issues/5240, seems to be
a bug in pip or related infrastructure.