### PR TITLE
Include the dem_uart module in the compute tile.

### DIFF
--- a/examples/fpga/nexys4ddr/compute_tile/rtl/verilog/compute_tile_dm_nexys4.sv
+++ b/examples/fpga/nexys4ddr/compute_tile/rtl/verilog/compute_tile_dm_nexys4.sv
@@ -92,6 +92,7 @@ module compute_tile_dm_nexys4
                       USE_DEBUG: 1,
                       DEBUG_STM: 1,
                       DEBUG_CTM: 1,
+                      DEBUG_DEM_UART: 1,
                       DEBUG_SUBNET_BITS: 6,
                       DEBUG_LOCAL_SUBNET: 0,
                       DEBUG_ROUTER_BUFFER_SIZE: 4,

--- a/examples/fpga/nexys4ddr/system_2x2_cccc/rtl/verilog/system_2x2_cccc_nexys4.sv
+++ b/examples/fpga/nexys4ddr/system_2x2_cccc/rtl/verilog/system_2x2_cccc_nexys4.sv
@@ -95,6 +95,7 @@ module system_2x2_cccc_nexys4
                       USE_DEBUG: 1,
                       DEBUG_STM: 1,
                       DEBUG_CTM: 1,
+                      DEBUG_DEM_UART: 0,
                       DEBUG_SUBNET_BITS: 6,
                       DEBUG_LOCAL_SUBNET: 0,
                       DEBUG_ROUTER_BUFFER_SIZE: 4,

--- a/examples/fpga/vcu108/compute_tile/rtl/verilog/compute_tile_dm_vcu108.sv
+++ b/examples/fpga/vcu108/compute_tile/rtl/verilog/compute_tile_dm_vcu108.sv
@@ -136,6 +136,7 @@ module compute_tile_dm_vcu108
                       USE_DEBUG: 1,
                       DEBUG_STM: 1,
                       DEBUG_CTM: 1,
+                      DEBUG_DEM_UART: 1,
                       DEBUG_SUBNET_BITS: 6,
                       DEBUG_LOCAL_SUBNET: 0,
                       DEBUG_ROUTER_BUFFER_SIZE: 4,

--- a/examples/fpga/vcu108/system_2x2_cccc/rtl/verilog/system_2x2_cccc_vcu108.sv
+++ b/examples/fpga/vcu108/system_2x2_cccc/rtl/verilog/system_2x2_cccc_vcu108.sv
@@ -141,6 +141,7 @@ module system_2x2_cccc_vcu108
          USE_DEBUG: 1,
          DEBUG_STM: 1,
          DEBUG_CTM: 1,
+         DEBUG_DEM_UART: 0,
          DEBUG_SUBNET_BITS: 6,
          DEBUG_LOCAL_SUBNET: 0,
          DEBUG_ROUTER_BUFFER_SIZE: 4,

--- a/examples/sim/compute_tile/tb_compute_tile.sv
+++ b/examples/sim/compute_tile/tb_compute_tile.sv
@@ -79,6 +79,7 @@ module tb_compute_tile
                       USE_DEBUG: 1'(USE_DEBUG),
                       DEBUG_STM: 1,
                       DEBUG_CTM: 1,
+                      DEBUG_DEM_UART: 1,
                       DEBUG_SUBNET_BITS: 6,
                       DEBUG_LOCAL_SUBNET: 0,
                       DEBUG_ROUTER_BUFFER_SIZE: 4,

--- a/examples/sim/system_2x2_cccc/tb_system_2x2_cccc.sv
+++ b/examples/sim/system_2x2_cccc/tb_system_2x2_cccc.sv
@@ -81,6 +81,7 @@ module tb_system_2x2_cccc(
                       USE_DEBUG: 1'(USE_DEBUG),
                       DEBUG_STM: 1,
                       DEBUG_CTM: 1,
+                      DEBUG_DEM_UART: 0,
                       DEBUG_SUBNET_BITS: 6,
                       DEBUG_LOCAL_SUBNET: 0,
                       DEBUG_ROUTER_BUFFER_SIZE: 4,

--- a/src/soc/hw/compute_tile_dm/compute_tile_dm.core
+++ b/src/soc/hw/compute_tile_dm/compute_tile_dm.core
@@ -12,6 +12,7 @@ depend =
   opensocdebug:interfaces:mor1kx_trace_exec
   opensocdebug:modules:stm_mor1kx
   opensocdebug:modules:ctm_mor1kx
+  opensocdebug:modules:dem_uart_wb
   optimsoc:base:config
   optimsoc:base:functions
 

--- a/src/soc/hw/networkadapter_ct/verilog/networkadapter_ct.sv
+++ b/src/soc/hw/networkadapter_ct/verilog/networkadapter_ct.sv
@@ -216,13 +216,13 @@ module networkadapter_ct
       .wb_stb_i      (wbif_stb_i[ID_MPSIMPLE]),
       .wb_dat_i      (wbif_dat_i[ID_MPSIMPLE*32 +: 32]),
 
-      .irq           (irq[1])
+      .irq           (irq[0])
       );
 
    generate
       if (CONFIG.NA_ENABLE_DMA) begin
          wire [3:0] irq_dma;
-         assign irq[0] = |irq_dma;
+         assign irq[1] = |irq_dma;
 
          wire [1:0][CONFIG.NOC_FLIT_WIDTH+1:0] dma_in_flit, dma_out_flit;
    assign dma_in_flit[0] = {mod_in_last[C_DMA_REQ], 1'b0, mod_in_flit[C_DMA_REQ]};
@@ -292,7 +292,7 @@ module networkadapter_ct
          .wb_dat_i                (wbm_dat_i),             // Templated
          .wb_ack_i                (wbm_ack_i));            // Templated
 end else begin // if (CONFIG.NA_ENABLE_DMA)
-   assign irq[0] = 1'b0;
+   assign irq[1] = 1'b0;
 end
 endgenerate
 

--- a/src/soc/hw/util/optimsoc_config.sv
+++ b/src/soc/hw/util/optimsoc_config.sv
@@ -82,6 +82,7 @@ package optimsoc_config;
       logic              USE_DEBUG;
       logic              DEBUG_STM;
       logic              DEBUG_CTM;
+      logic              DEBUG_DEM_UART;
       integer            DEBUG_SUBNET_BITS;
       integer            DEBUG_LOCAL_SUBNET;
       integer            DEBUG_ROUTER_BUFFER_SIZE;
@@ -131,6 +132,7 @@ package optimsoc_config;
       logic              USE_DEBUG;
       logic              DEBUG_STM;
       logic              DEBUG_CTM;
+      logic              DEBUG_DEM_UART;
       integer            DEBUG_SUBNET_BITS;
       integer            DEBUG_LOCAL_SUBNET;
       integer            DEBUG_ROUTER_BUFFER_SIZE;
@@ -167,6 +169,7 @@ package optimsoc_config;
       derive_config.USE_DEBUG = conf.USE_DEBUG;
       derive_config.DEBUG_STM = conf.DEBUG_STM;
       derive_config.DEBUG_CTM = conf.DEBUG_CTM;
+      derive_config.DEBUG_DEM_UART = conf.DEBUG_DEM_UART;
       derive_config.DEBUG_SUBNET_BITS = conf.DEBUG_SUBNET_BITS;
       derive_config.DEBUG_LOCAL_SUBNET = conf.DEBUG_LOCAL_SUBNET;
       derive_config.DEBUG_ROUTER_BUFFER_SIZE = conf.DEBUG_ROUTER_BUFFER_SIZE;
@@ -183,6 +186,7 @@ package optimsoc_config;
       derive_config.DEBUG_MODS_PER_CORE = (int'(conf.DEBUG_STM) + int'(conf.DEBUG_CTM)) * int'(conf.USE_DEBUG);
       derive_config.DEBUG_MODS_PER_TILE = conf.USE_DEBUG *
                                           (1 /* MAM */
+                                           + int'(conf.DEBUG_DEM_UART)
                                            + derive_config.DEBUG_MODS_PER_CORE * conf.CORES_PER_TILE);
       derive_config.DEBUG_NUM_MODS = conf.USE_DEBUG *
                                      (1 /* SCM */


### PR DESCRIPTION
Adjusted the optimsoc_config struct so the dem_uart will only be generated
if needed. Furthermore, adjusted the examples so the dem_uart is generated
for a single compute tile but not for the system 2x2.

@wallento , @imphil , please have a look and see if this makes sense to you or if I forgot something.