### PR TITLE
Add Eclipse Oomph installation description

### DIFF
--- a/devenv/eclipse-setups/optimsoc.products.setup
+++ b/devenv/eclipse-setups/optimsoc.products.setup
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:ProductCatalog
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
+    name="optimsoc.products"
+    label="OpTiMSoC Products">
+
+  <setupTask
+      xsi:type="setup:InstallationTask"
+      id="installation"/>
+  <setupTask
+      xsi:type="setup.p2:P2Task">
+    <requirement
+        name="org.eclipse.oomph.setup.feature.group"/>
+    <repository
+        url="${oomph.update.url}"/>
+  </setupTask>
+
+  <!-- Set default preferences -->
+  <setupTask
+      xsi:type="setup:CompoundTask"
+      name="preferences">
+    <setupTask
+        xsi:type="setup:PreferenceTask"
+        key="/instance/org.eclipse.ui.editors/lineNumberRuler"
+        value="true"/>
+    <setupTask
+        xsi:type="setup:PreferenceTask"
+        key="/instance/org.eclipse.core.resources/refresh.enabled"
+        value="true"/>
+    <setupTask
+        xsi:type="setup:PreferenceTask"
+        key="/instance/org.eclipse.core.resources/encoding"
+        value="UTF-8"/>
+    <setupTask
+        xsi:type="setup:PreferenceTask"
+        key="/instance/org.eclipse.ui.editors/printMarginColumn"
+        value="80"/>
+    <setupTask
+        xsi:type="setup:PreferenceTask"
+        key="/instance/org.eclipse.ui.editors/spacesForTabs"
+        value="true"/>
+    <setupTask
+        xsi:type="setup:PreferenceTask"
+        key="/instance/org.eclipse.ui.editors/tabWidth"
+        value="3"/>
+  </setupTask>
+
+
+  <!-- Create .desktop file -->
+  <setupTask
+      xsi:type="setup:ResourceCreationTask"
+      excludedTriggers="STARTUP MANUAL"
+      filter="(osgi.os=linux)"
+      content="[Desktop Entry]&#xA;Type=Application&#xA;Name=${scope.product.label}&#xA;Exec=${product.location/}eclipse&#xA;Icon=${product.location/}optimsoc-icon.png&#xA;Terminal=false&#xA;Categories=Development;IDE;"
+      targetURL="${product.location|uri}/optimsocide.desktop"/>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="product.location"
+      value="${installation.location/}${installation.relativeProductFolder}"/>
+  <setupTask
+      xsi:type="setup:ResourceCopyTask"
+      excludedTriggers="STARTUP MANUAL"
+      filter="(osgi.os=linux)"
+      sourceURL="${product.location|uri}/optimsocide.desktop"
+      targetURL="${HOME}/.local/share/applications/optimsocide.desktop"/>
+  <setupTask
+      xsi:type="setup:ResourceCopyTask"
+      excludedTriggers="STARTUP MANUAL"
+      filter="(osgi.os=linux)"
+      sourceURL="https://www.optimsoc.org/img/optimsoc_logo.png"
+      targetURL="${product.location}/optimsoc-icon.png"/>
+
+  <product name="optimsoc.products.ide" label="OpTiMSoC IDE">
+    <annotation
+          source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+      <detail
+          key="imageURI">
+        <value>https://www.optimsoc.org/img/optimsoc_logo.png</value>
+      </detail>
+      <detail
+          key="siteURI">
+        <value>https://www.optimsoc.org</value>
+      </detail>
+      <detail
+          key="folderName">
+        <value>optimsocide</value>
+      </detail>
+      <detail
+          key="folderName.macosx">
+        <value>OptimsocIde</value>
+      </detail>
+    </annotation>
+    <version
+        name="latest"
+        label="latest"
+        requiredJavaVersion="1.8">
+      <setupTask
+          xsi:type="setup.p2:P2Task"
+          label="${scope.product.label}"
+          licenseConfirmationDisabled="true">
+        <repository
+            url="http://download.eclipse.org/releases/2018-09"/>
+
+        <!-- base IDE -->
+        <requirement
+            name="org.eclipse.platform.ide"/>
+        <requirement
+            name="org.eclipse.platform.feature.group"/>
+        <requirement
+            name="org.eclipse.rcp.feature.group"/>
+
+        <!-- C/C++ (CDT and friends) -->
+        <requirement
+            name="epp.package.cpp"/>
+        <requirement
+            name="org.eclipse.cdt.autotools.feature.group"/>
+        <requirement
+            name="org.eclipse.cdt.build.crossgcc.feature.group"/>
+        <requirement
+            name="org.eclipse.cdt.feature.group"/>
+        <requirement
+            name="org.eclipse.cdt.launch.remote.feature.group"/>
+        <requirement
+            name="org.eclipse.cdt.mylyn.feature.group"/>
+        <requirement
+            name="org.eclipse.egit.feature.group"/>
+        <requirement
+            name="org.eclipse.linuxtools.cdt.libhover.devhelp.feature.feature.group"/>
+        <requirement
+            name="org.eclipse.linuxtools.cdt.libhover.feature.feature.group"/>
+        <requirement
+            name="org.eclipse.linuxtools.changelog.c.feature.group"/>
+
+        <!-- TCL -->
+        <requirement
+            name="org.eclipse.dltk.core.feature.group"/>
+        <requirement
+            name="org.eclipse.dltk.tcl.feature.group"/>
+
+        <!-- Python -->
+        <repository
+            url="http://www.pydev.org/updates"/>
+        <requirement
+            name="org.python.pydev.feature.feature.group"
+            filter=""/>
+
+        <!-- SystemVerilog support (SVEditor) -->
+        <repository
+            url="http://sveditor.sourceforge.net/update"/>
+        <requirement
+            name="net.sf.sveditor.feature.group"
+            filter=""/>
+
+        <!-- ReST editor (to edit documentation)-->
+        <repository
+            url="http://resteditor.sourceforge.net/eclipse"/>
+        <requirement
+            name="org.psem2m.eclipse.rest.editor.feature.group"/>
+
+        <!-- yedit (YAML editor) -->
+        <requirement
+            name="org.dadacoalition.yedit.feature.feature.group"/>
+        <repository
+            url="http://dadacoalition.org/yedit"/>
+      </setupTask>
+      <description>OpTiMSoC Development Environment based on Eclipse</description>
+    </version>
+    <description>A development environment for creating projects with OpTiMSoC and hacking OpTiMSoC itself. Both for hardware and software engineers.</description>
+  </product>
+  <description>Eclipse products for the development and use with OpTiMSoC.</description>
+</setup:ProductCatalog>

--- a/devenv/eclipse-setups/optimsoc.project.develop-hw.setup
+++ b/devenv/eclipse-setups/optimsoc.project.develop-hw.setup
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Project
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    name="optimsoc.project.develop-hw"
+    label="Develop on OpTiMSoC hardware components">
+  <setupTask
+      xsi:type="setup:CompoundTask"
+      name="User Preferences">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/UserPreferences"/>
+  </setupTask>
+  <stream name="master"
+      label="master">
+    <description>master</description>
+  </stream>
+  <description>This project allows you to enhance the hardware components in OpTiMSoC</description>
+</setup:Project>

--- a/devenv/eclipse-setups/optimsoc.projects.setup
+++ b/devenv/eclipse-setups/optimsoc.projects.setup
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:ProjectCatalog
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    name="org.optimsoc.projects"
+    label="OpTiMSoC Projects">
+  <setupTask
+      xsi:type="setup:WorkspaceTask"
+      id="workspace"/>
+  <setupTask
+      xsi:type="setup:ResourceCreationTask"
+      content="MAX_RECENT_WORKSPACES=5&#xD;&#xA;RECENT_WORKSPACES=${workspace.location|property}&#xD;&#xA;RECENT_WORKSPACES_PROTOCOL=3&#xD;&#xA;SHOW_WORKSPACE_SELECTION_DIALOG=true&#xD;&#xA;eclipse.preferences.version=1"
+      targetURL="configuration:/.settings/org.eclipse.ui.ide.prefs"/>
+  <setupTask
+      xsi:type="setup:TextModifyTask"
+      url="configuration:/config.ini">
+    <modification
+        pattern="osgi\.instance\.area\.default=(@user\.home/optimsoc-workspace)">
+      <substitution>${workspace.location|path}</substitution>
+    </modification>
+  </setupTask>
+  <project name="optimsoc-dev"
+      label="Enhance OpTiMSoC itself">
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="User Preferences">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/UserPreferences"/>
+    </setupTask>
+    <project
+        href="optimsoc.project.develop-hw.setup#/"/>
+  </project>
+  <project name="optimsoc-user"
+      label="Build on top of OpTiMSoC"/>
+  <description>Projects in the scope of OpTiMSoC</description>
+</setup:ProjectCatalog>

--- a/devenv/eclipse-setups/org.eclipse.setup
+++ b/devenv/eclipse-setups/org.eclipse.setup
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Index
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    name="optimsoc.index"
+    label="OpTiMSoC Setup Index">
+
+  <productCatalog
+      href="optimsoc.products.setup#/"/>
+  <projectCatalog
+      href="optimsoc.projects.setup#/"/>
+</setup:Index>

--- a/devenv/install-optimsocide.sh
+++ b/devenv/install-optimsocide.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Install a customized version of Eclipse for OpTiMSoC Development
+#
+# The installation and customization of Eclipse is performed through the
+# mechanisms provided by Oomph. This script just downloads the installer and
+# starts it.
+#
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEMPDIR="$(mktemp -d)"
+
+INSTALLER_URL='https://www.eclipse.org/downloads/download.php?file=/oomph/products/eclipse-inst-linux64.tar.gz&r=1'
+
+echo -n 'Downloading Eclipse installer...'
+curl -Ls -o $TEMPDIR/eclipse-installer.tar.gz "$INSTALLER_URL"
+echo ' done'
+
+echo -n 'Extracting installer...'
+tar -x -C $TEMPDIR -f $TEMPDIR/eclipse-installer.tar.gz
+echo ' done'
+
+# The Oomph installer uses a ResourceCopyTask to copy the optimsocide.desktop
+# file to the user's applications directory. Since this task is not able to
+# overwrite existing files, we delete a potentially existing old .desktop file
+# here.
+echo -n 'Deleting old .desktop file...'
+rm -f $HOME/.local/share/applications/optimsocide.desktop 2>/dev/null
+echo ' done'
+
+echo 'Starting installation process...'
+$TEMPDIR/eclipse-installer/eclipse-inst -vmargs "-Doomph.redirection.setups=http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/->$THIS_DIR/eclipse-setups/"
+
+rm -r "$TEMPDIR"
+
+echo
+echo "The OpTiMSoC IDE is now ready to be used."
+echo "You can launch it from the the start menu by searching for 'OpTiMSoC IDE'."
+echo "Enjoy!"


### PR DESCRIPTION
The Eclipse Installer is based on Oomph and can be used to install
customized Eclipse installations. We use this for OpTiMSoC to give users
a easy way of installing Eclipse with all required settings.

Currently, the Easy Installation mode only allows the selection of a
product, not a project. The project part should therefore be considered
experimental and possibly disabled.