### PR TITLE
Spyglass finalize

### DIFF
--- a/doc/user_guide/develop.rst
+++ b/doc/user_guide/develop.rst
@@ -68,6 +68,59 @@ So let's look at a couple of examples how to build a SoC hardware with fusesoc.
 
      fusesoc --cores-root $OPTIMSOC_SOURCE/examples pgm optimsoc:examples:system_2x2_cccc_nexys4ddr
 
+Linting Hardware
+================
+
+When writing hardware code it's easy to make small mistakes which result in a non-working design.
+A great help to write working code are static analysis or lint tools.
+Such tools go through the Verilog code and check if certain rules of "good programming" are obeyed.
+
+The OpTiMSoC source code supports two lint tools, the commercial Synopsys Spyglass tools, and the open source Verilator tool.
+
+Linting with Spyglass
+---------------------
+
+Synopsys Spyglass offers an extensive set of lint rules.
+To run Spyglass, the fusesoc core file of the design must be prepared for it.
+We did that in all our example systems; just look at them to learn about the required settings.
+
+To run Spyglass use ``fusesoc run`` with the ``--target=lint`` argument and specify that you want to use Spyglass by adding the option ``--tool=spyglass`` to it.
+The full command line to lint a simple ``compute_tile`` system for the Nexys 4 DDR board looks like this.
+
+.. code:: sh
+
+    # --no-export is useful for development and waiving messages.
+    # Do not use it when running lint in CI environments.
+    fusesoc --cores-root $OPTIMSOC_SOURCE/examples run --target=lint --tool=spyglass --no-export optimsoc:examples:compute_tile_nexys4ddr
+
+At the end of the process Spyglass writes a summary of its findings.
+It could look like this:
+
+.. code:: plain
+
+   ---------------------------------------------------------------------------------------------------
+      Goal Violation Summary:
+          Waived   Messages:                      2 Errors,      0 Warnings,      0 Infos
+          Reported Messages:         0 Fatals,  153 Errors,    521 Warnings,     10 Infos
+   ---------------------------------------------------------------------------------------------------
+
+If any warnings, errors, or fatal errors are found, we consider the linting "failed" and fusesoc returns a non-zero exit code.
+Hence you need to fix all those messages.
+You have two options for that: either fix the source code, or tell Spyglass that this message is bogous by "waiving" the message.
+
+To make things easier, Spyglass offers a nice GUI.
+Open it in the following way:
+
+.. code:: sh
+
+   cd build/optimsoc_examples_compute_tile_nexys4ddr_0/lint-spyglass
+   make run-gui
+
+You can then graphically view the violations and waive them as needed.
+Be aware that waivers are by default saved into a new file within the build directory.
+To be permanent, you need to copy them from there to the ``spyglass-waiver.awl`` file in the OpTiMSoC source directory.
+
+
 Choosing an Editor/IDE
 ======================
 

--- a/examples/fpga/nexys4ddr/compute_tile/compute_tile_nexys4ddr.core
+++ b/examples/fpga/nexys4ddr/compute_tile/compute_tile_nexys4ddr.core
@@ -24,6 +24,11 @@ filesets:
       - tbench/verilog/tb_compute_tile_nexys4ddr.sv
     file_type: systemVerilogSource
 
+  files_spyglass_waivers:
+    files:
+      - spyglass-waiver.awl
+    file_type: awl
+
 targets:
   synth:
     default_tool: vivado
@@ -41,6 +46,24 @@ targets:
       - files_testbench
     tools:
       xsim: ~
+
+  lint:
+    default_tool: spyglass
+    filesets:
+      - files_rtl
+      - files_spyglass_waivers
+    toplevel: [compute_tile_dm_nexys4]
+    tools:
+      spyglass:
+        spyglass_options:
+          - handlememory 1
+
+        rule_parameters:
+          # Do not give W263 when using a localparam within a case, as we
+          # typically do for state machines.
+          - handle_static_caselabels 1
+      verilator:
+        mode: lint-only
 
 parameters:
   NUM_CORES:

--- a/examples/fpga/nexys4ddr/compute_tile/rtl/verilog/compute_tile_dm_nexys4.sv
+++ b/examples/fpga/nexys4ddr/compute_tile/rtl/verilog/compute_tile_dm_nexys4.sv
@@ -64,7 +64,7 @@ module compute_tile_dm_nexys4
    localparam integer LMEM_SIZE = 128*1024*1024;
 
    localparam AXI_ID_WIDTH = 4;
-   localparam DDR_ADDR_WIDTH = 28;
+   localparam DDR_ADDR_WIDTH = 32;
    localparam DDR_DATA_WIDTH = 32;
 
    localparam base_config_t

--- a/examples/fpga/nexys4ddr/compute_tile/spyglass-waiver.awl
+++ b/examples/fpga/nexys4ddr/compute_tile/spyglass-waiver.awl
@@ -1,0 +1,116 @@
+#
+# Waivers for Spyglass lint
+#
+
+# Blackboxes for Xilinx IP are expected
+waive -msg {Design Unit 'clk_gen_ddr' has no definition; black-box behavior assumed}  -rule {  {ErrorAnalyzeBBox}  } 
+waive -msg {Design Unit 'mig_7series' has no definition; black-box behavior assumed}  -rule {  {ErrorAnalyzeBBox}  } 
+
+# "Initial Assignment at Declaration for ( <MODULE> ) is ignored by synthesis"
+waive -rule {  {SynthesisWarning}  {SYNTH_89}  }  -comment {Initial assignments are fine in FPGA designs.} 
+
+# "Initial block is ignored for synthesis"
+waive -rule {  {SYNTH_5143}  }  -comment {Initial blocks are useful for simulation, and can be safely ignored in synthesis. }
+
+# For easier debugging/viewing in waveform viewers, we sometimes assign X to unused signals.
+waive -rule {  {NoAssignX-ML}  }  -comment {Do not assignment of X as error, we use this for debugging.}
+
+# clog2() is fine
+waive -msg {*'clog2'*}  -rules {  {W481a} {W499} } -comment {Standard clog2() code which is known to work.}
+
+# Passing a constant to an enable signal isn't a big deal.
+waive -rule {  {FlopEConst}  }  -comment {Passing a constant to an enable signal isn't a big deal.} 
+
+# Unconnected outputs (e.g. ".signal()" in an instantiation)
+waive -rule { {W287a}  {W287b}  }  
+ 
+# "Signal may be multiply assigned (beside initialization) in the same scope."
+# We do this regularly in our state machine code
+waive -rule {  {W415a}  } 
+
+# Ignore warnings about unread bits and variables
+# W528: "A signal or variable is set but never read"
+# W240: "Following Bits of signal ... are not read"
+waive -rule { W528 W240 }
+
+# XXX: We need to globally waive the W123 rule even though it would be useful.
+# I didn't find another way to waive the warning
+# "W123 : Following Bits of signal 'pstep' (File Name: ../../../../../../../../home/no56hud/src/optimsoc/objdir/dist/external/mor1kx/rtl/verilog/mor1kx_ctrl_cappuccino.v Line No.: 468) are read but not set
+#   [2:0] "
+# which is within the SignalUsageReport.
+waive -rule { W123 }
+
+##########################################################
+# mor1kx
+##########################################################
+
+# mor1kx: waive uncritical warnings from imported code 
+waive -du {  {mor1kx_fetch_cappuccino}  }  -msg {Combinational and sequential parts of an FSM 'mor1kx_fetch_cappuccino.state' described in same always block}  -rule {  {STARC05-2.11.3.1}  }   
+waive -du {  {mor1kx_icache}  }  -msg {Combinational and sequential parts of an FSM 'mor1kx_icache.state' described in same always block}  -rule {  {STARC05-2.11.3.1}  } 
+waive -du {  {mor1kx_lsu_cappuccino}  }  -msg {Combinational and sequential parts of an FSM 'mor1kx_lsu_cappuccino.state' described in same always block}  -rule {  {STARC05-2.11.3.1}  }
+
+# Bit/range selects on integers are harmless, but trigger warnings
+# XXX: Fix them in the mor1kx code
+waive -du {  {mor1kx_rf_cappuccino}  }  -msg {Inappropriate bit select for int_bit_sel variable: \"in[i]\"}  -severity {  {Warning}  }  -rule {  {W215}  }  -weight {5} 
+waive -du {  {mor1kx_rf_cappuccino}  }  -msg {Inappropriate bit select for int_bit_sel variable: \"in[i]\"}  -severity {  {Warning}  }  -rule {  {W215}  }  -weight {5} 
+waive -du {  {mor1kx_rf_cappuccino}  }  -msg {Inappropriate bit select for int_bit_sel variable: \"in[i]\"}  -severity {  {Warning}  }  -rule {  {W215}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_rf_cappuccino}  }  -msg {Inappropriate range select for int_part_sel variable: \"in[i +:8] \"}  -severity {  {Warning}  }  -rule {  {W216}  }  -weight {5}   
+waive -du {  {mor1kx_immu}  }  -msg {Inappropriate range select for int_part_sel variable: \"j[(WAYS_WIDTH - 1):0] \"}  -severity {  {Warning}  }  -rule {  {W216}  }  -weight {5} 
+waive -du {  {mor1kx_immu}  }  -msg {Inappropriate range select for int_part_sel variable: \"j[(WAYS_WIDTH - 1):0] \"}  -severity {  {Warning}  }  -rule {  {W216}  }  -weight {5} 
+waive -du {  {mor1kx_dmmu}  }  -msg {Inappropriate range select for int_part_sel variable: \"j[(WAYS_WIDTH - 1):0] \"}  -severity {  {Warning}  }  -rule {  {W216}  }  -weight {5} 
+waive -du {  {mor1kx_dmmu}  }  -msg {Inappropriate range select for int_part_sel variable: \"j[(WAYS_WIDTH - 1):0] \"}  -severity {  {Warning}  }  -rule {  {W216}  }  -weight {5} 
+
+# STARC05-2.2.3.3 
+waive -du {  {mor1kx_fetch_cappuccino}  }  -msg {Flipflop 'ibus_req' is assigned over the same signal in an always construct for sequential circuits (at line '383')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_fetch_cappuccino}  }  -msg {Flipflop 'state' is assigned over the same signal in an always construct for sequential circuits (at line '388')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_icache}  }  -msg {Flipflop 'spr_bus_ack_o' is assigned over the same signal in an always construct for sequential circuits (at line '305')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_icache}  }  -msg {Flipflop 'state' is assigned over the same signal in an always construct for sequential circuits (at line '267')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_icache}  }  -msg {Flipflop 'state' is assigned over the same signal in an always construct for sequential circuits (at line '267')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_icache}  }  -msg {Flipflop 'state' is assigned over the same signal in an always construct for sequential circuits (at line '267')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_lsu_cappuccino}  }  -msg {Flipflop 'dbus_req_o' is assigned over the same signal in an always construct for sequential circuits (at line '449')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_lsu_cappuccino}  }  -msg {Flipflop 'state' is assigned over the same signal in an always construct for sequential circuits (at line '450')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_lsu_cappuccino}  }  -msg {Flipflop 'last_write' is assigned over the same signal in an always construct for sequential circuits (at line '479')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_lsu_cappuccino}  }  -msg {Flipflop 'state' is assigned over the same signal in an always construct for sequential circuits (at line '412')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+waive -du {  {mor1kx_ctrl_cappuccino}  }  -msg {Flipflop 'spr_sr[14:0] ' is assigned over the same signal in an always construct for sequential circuits (at line '728')}  -severity {  {Warning}  }  -rule {  {STARC05-2.2.3.3}  }  -weight {5}  -exact 
+
+# unassigned signals
+waive -du {  {mor1kx_ctrl_cappuccino}  }  -rule { W240 }
+
+# Detected undriven input terminal 
+waive -du {  {mor1kx_ctrl_cappuccino} {mor1kx_dmmu}  } -rule {  {UndrivenInTerm-ML}  }   
+
+waive -du { mor1kx_cpu_cappuccino }  -msg {Detected undriven input terminal compute_tile_dm_nexys4.u_compute_tile.\gen_cores[0].u_core .u_cpu.mor1kx_cpu.\cappuccino.mor1kx_cpu .mor1kx_ctrl_cappuccino.spr_bus_dat_ic_i[31:0]}  -severity {  {Error}  }  -rule {  {UndrivenInTerm-ML}  }  -weight {10}  -exact
+
+
+##########################################################
+# lisnoc
+##########################################################
+# XXX: Some of these warnings should/could be fixed, but leaving LISNoC as-is for now
+waive -du {  {lisnoc_packet_buffer}  }  -msg {Loop index 'i' is not of type integer}  -severity {  {Warning}  }  -rule {  {W480}  }  -weight {5}  -exact 
+waive -du {  {lisnoc_dma_target}  }  -msg {Flipflop 'noc_resp_packet_wcount' is assigned over the same signal in an always construct for sequential circuits (at line '586')}  -rule {  {STARC05-2.2.3.3}  } 
+waive -du {  {lisnoc_dma_initiator_nocreq}  }  -msg {For operator (-), left expression: \"req_size\" width 30 should match right expression: \"noc_req_counter\" width 32. [Hierarchy: ':compute_tile_dm_nexys4:u_compute_tile@compute_tile_dm:u_na@networkadapter_ct:\genblk1.u_dma @lisnoc_dma:ctrl_initiator@lisnoc_dma_initiator:u_nocreq@lisnoc_dma_initiator_nocreq']}  -severity {  {Warning}  }  -rule {  {W116}  }  -weight {10}  -exact 
+waive -du {  {lisnoc_dma_initiator_nocreq}  }  -msg {For operator (-), left expression: \"req_size\" width 30 should match right expression: \"noc_req_counter\" width 32. [Hierarchy: ':compute_tile_dm_nexys4:u_compute_tile@compute_tile_dm:u_na@networkadapter_ct:\genblk1.u_dma @lisnoc_dma:ctrl_initiator@lisnoc_dma_initiator:u_nocreq@lisnoc_dma_initiator_nocreq']}  -severity {  {Warning}  }  -rule {  {W116}  }  -weight {10}  -exact 
+waive -du {  {lisnoc_dma_target}  }  -msg {For operator (-), left expression: \"resp_wsize\" width 30 should match right expression: \"noc_resp_wcounter\" width 32. [Hierarchy: ':compute_tile_dm_nexys4:u_compute_tile@compute_tile_dm:u_na@networkadapter_ct:\genblk1.u_dma @lisnoc_dma:target@lisnoc_dma_target']}  -severity {  {Warning}  }  -rule {  {W116}  }  -weight {10}  -exact 
+waive -du {  {lisnoc_dma_target}  }  -msg {For operator (-), left expression: \"resp_wsize\" width 30 should match right expression: \"noc_resp_wcounter\" width 32. [Hierarchy: ':compute_tile_dm_nexys4:u_compute_tile@compute_tile_dm:u_na@networkadapter_ct:\genblk1.u_dma @lisnoc_dma:target@lisnoc_dma_target']}  -severity {  {Warning}  }  -rule {  {W116}  }  -weight {10}  -exact 
+ 
+waive -du {  {lisnoc_dma_initiator_nocreq}  }  -msg {For operator (==), left expression: \"(noc_req_packet_count + noc_req_counter)\" width 32 should match right expression: \"req_size\" width 30 [Hierarchy: ':compute_tile_dm_nexys4:u_compute_tile@compute_tile_dm:u_na@networkadapter_ct:\genblk1.u_dma @lisnoc_dma:ctrl_initiator@lisnoc_dma_initiator:u_nocreq@lisnoc_dma_initiator_nocreq']}  -rule {  {W362}  }  
+waive -du {  {lisnoc_dma_target}  }  -msg {For operator (==), left expression: \"wb_resp_count\" width 12 should match right expression: \"resp_wsize\" width 30 [Hierarchy: ':compute_tile_dm_nexys4:u_compute_tile@compute_tile_dm:u_na@networkadapter_ct:\genblk1.u_dma @lisnoc_dma:target@lisnoc_dma_target']}  -rule {  {W362}  }  
+waive -du {  {lisnoc_dma_target}  }  -msg {For operator (==), left expression: \"wb_resp_count\" width 12 should match right expression: \"resp_wsize\" width 30 [Hierarchy: ':compute_tile_dm_nexys4:u_compute_tile@compute_tile_dm:u_na@networkadapter_ct:\genblk1.u_dma @lisnoc_dma:target@lisnoc_dma_target']}  -rule {  {W362}  }  
+
+
+##########################################################
+# Open SoC Debug
+##########################################################
+waive -du {  {osd_mam}  }  -msg {Not all bits of the function 'endian_conv' value are set in the function body or in all branches of the function*} -rule {  {W499}  }
+
+waive -du {  {osd_stm_mor1kx}  }  -msg {Input 'trace_port.*' declared but not read.*} -rule {  {W240}  } 
+waive -du {  {osd_ctm}  }  -msg {Input 'trace_*' declared but not read.*} -rule {  {W240}  } 
+waive -du {  {osd_dem_uart_wb}  }  -msg {Input 'wb_cti_i[2:0]' declared but not read.*}  -rule {  {W240}  }  
+waive -du {  {osd_dem_uart_wb}  }  -msg {Input 'wb_bte_i[1:0]' declared but not read.*}  -rule {  {W240}  }  
+waive -du {  {osd_mam_wb_if}  }  -msg {Input 'write_strb[3:0]' declared but not read.*}  -rule {  {W240}  }  
+
+
+##########################################################
+# GLIP
+##########################################################
+waive -msg {Function should not set a global variable: *} -rule {  {W424}  } 

--- a/external/extra_cores/boards/nexys4ddr/rtl/verilog/nexys4ddr.sv
+++ b/external/extra_cores/boards/nexys4ddr/rtl/verilog/nexys4ddr.sv
@@ -63,7 +63,7 @@ module nexys4ddr
    output                sys_rst,
 
    input [3:0]           ddr_awid,
-   input [27:0]          ddr_awaddr,
+   input [31:0]          ddr_awaddr,
    input [7:0]           ddr_awlen,
    input [2:0]           ddr_awsize,
    input [1:0]           ddr_awburst,
@@ -82,7 +82,7 @@ module nexys4ddr
    output                ddr_bvalid,
    input                 ddr_bready,
    input [3:0]           ddr_arid,
-   input [27:0]          ddr_araddr,
+   input [31:0]          ddr_araddr,
    input [7:0]           ddr_arlen,
    input [2:0]           ddr_arsize,
    input [1:0]           ddr_arburst,
@@ -185,8 +185,7 @@ module nexys4ddr
 
    mig_7series
      u_mig_7series
-       (.*,
-        .init_calib_complete            (ddr_calib_done),
+       (.init_calib_complete            (ddr_calib_done),
         .sys_clk_i                      (clk_ddr_sys),
 //        .clk_ref_i                      (clk_ddr_ref),
         .sys_rst                        (clk_ddr_locked | rst),
@@ -213,7 +212,7 @@ module nexys4ddr
 
         // Slave Interface Write Address Ports
         .s_axi_awid                     (ddr_awid),
-        .s_axi_awaddr                   (ddr_awaddr),
+        .s_axi_awaddr                   (ddr_awaddr[27:0]),
         .s_axi_awlen                    (ddr_awlen),
         .s_axi_awsize                   (ddr_awsize),
         .s_axi_awburst                  (ddr_awburst),
@@ -236,7 +235,7 @@ module nexys4ddr
         .s_axi_bready                   (ddr_bready),
         // Slave Interface Read Address Ports
         .s_axi_arid                     (ddr_arid),
-        .s_axi_araddr                   (ddr_araddr),
+        .s_axi_araddr                   (ddr_araddr[27:0]),
         .s_axi_arlen                    (ddr_arlen),
         .s_axi_arsize                   (ddr_arsize),
         .s_axi_arburst                  (ddr_arburst),

--- a/external/glip/src/common/logic/credit/verilog/creditor.v
+++ b/external/glip/src/common/logic/credit/verilog/creditor.v
@@ -33,19 +33,19 @@ module creditor
    (
     input                         clk,
     input                         rst,
-    
+
     input                         payback,
     output reg [CREDIT_WIDTH-1:0] credit,
     input                         borrow,
     output reg                    grant,
-    
+
     output                        error
     );
-   
+
    reg [WIDTH-1:0]                resources = INITIAL_VALUE;
    reg [WIDTH:0]                  nxt_resources;
    reg [CREDIT_WIDTH-1:0]         nxt_credit;
-   
+
    // Error is an overflow of the resources. The host cannot payback
    // more than originally granted.
    assign error = nxt_resources[WIDTH] | (resources > INITIAL_VALUE);
@@ -64,9 +64,9 @@ module creditor
    always @(*) begin
       nxt_resources = resources;
       nxt_credit = credit;
-      
+
       grant = 0;
-      
+
       if (payback) begin
          nxt_resources = resources + 1;
       end else if (borrow) begin
@@ -85,5 +85,5 @@ module creditor
          end // else: !if(WIDTH > CREDIT_WIDTH)
       end
    end
-   
-endmodule // glip_creditgen
+
+endmodule

--- a/external/mor1kx/rtl/verilog/mor1kx_true_dpram_sclk.v
+++ b/external/mor1kx/rtl/verilog/mor1kx_true_dpram_sclk.v
@@ -16,13 +16,13 @@ module mor1kx_true_dpram_sclk
     parameter DATA_WIDTH = 32
     )
    (
-    input 		    clk,
+    input                   clk,
     input [ADDR_WIDTH-1:0]  addr_a,
-    input 		    we_a,
+    input                   we_a,
     input [DATA_WIDTH-1:0]  din_a,
     output [DATA_WIDTH-1:0] dout_a,
     input [ADDR_WIDTH-1:0]  addr_b,
-    input 		    we_b,
+    input                   we_b,
     input [DATA_WIDTH-1:0]  din_b,
     output [DATA_WIDTH-1:0] dout_b
     );
@@ -37,19 +37,17 @@ module mor1kx_true_dpram_sclk
 
    always @(posedge clk) begin
       if (we_a) begin
-	 mem[addr_a] <= din_a;
-	 rdata_a <= din_a;
+         mem[addr_a] <= din_a;
+         rdata_a <= din_a;
       end else begin
-	 rdata_a <= mem[addr_a];
+         rdata_a <= mem[addr_a];
       end
-   end
 
-   always @(posedge clk) begin
       if (we_b) begin
-	 mem[addr_b] <= din_b;
-	 rdata_b <= din_b;
+         mem[addr_b] <= din_b;
+         rdata_b <= din_b;
       end else begin
-	 rdata_b <= mem[addr_b];
+         rdata_b <= mem[addr_b];
       end
    end
 

--- a/external/opensocdebug/hardware/blocks/regaccess/common/osd_regaccess_demux.sv
+++ b/external/opensocdebug/hardware/blocks/regaccess/common/osd_regaccess_demux.sv
@@ -132,7 +132,7 @@ module osd_regaccess_demux
       & (buf_reg_is_bypass[2] | mark_bypass);
 
    logic no_buf_entry_is_tagged;
-   assign no_buf_entry_is_tagged = ~do_tag & ~(|buf_reg_is_regaccess | |buf_reg_is_bypass);
+   assign no_buf_entry_is_tagged = ~do_tag & ~((|buf_reg_is_regaccess) | (|buf_reg_is_bypass));
 
    assign in_ready = (out_bypass_ready & out_reg_ready) |
       (out_bypass_ready & (buf_reg_is_bypass[2] | mark_bypass)) |

--- a/external/opensocdebug/hardware/modules/ctm/common/osd_ctm.sv
+++ b/external/opensocdebug/hardware/modules/ctm/common/osd_ctm.sv
@@ -77,6 +77,9 @@ module osd_ctm
                .module_out (dp_in),
                .module_out_ready (dp_in_ready));
 
+   // this module cannot receive data except for configuration packets
+   assign dp_in_ready = 1'b0;
+
 
    always @(*) begin
       reg_ack = 1;

--- a/external/opensocdebug/hardware/modules/ctm/or1k/mor1kx/osd_ctm_mor1kx.sv
+++ b/external/opensocdebug/hardware/modules/ctm/or1k/mor1kx/osd_ctm_mor1kx.sv
@@ -67,5 +67,18 @@ module osd_ctm_mor1kx
    assign trace_jal = trace_port.jal;
    assign trace_jalr = trace_port.jr;
 
+   assign trace_branch = 1'b0;
+   assign trace_load = 1'b0;
+   assign trace_store = 1'b0;
+   assign trace_trap = 1'b0;
+   assign trace_xcpt = 1'b0;
+   assign trace_mem = 1'b0;
+   assign trace_csr = 1'b0;
+   assign trace_br_taken = 1'b0;
+   assign trace_prv = 2'b0;
+   assign trace_addr = ADDR_WIDTH'(1'b0);
+   assign trace_rdata = DATA_WIDTH'(1'b0);
+   assign trace_wdata = DATA_WIDTH'(1'b0);
+   assign trace_time = DATA_WIDTH'(1'b0);
 
 endmodule // osd_stm_mor1kx

--- a/update_externals.sh
+++ b/update_externals.sh
@@ -23,7 +23,7 @@ git subtree pull -m "Update external/mor1kx" --prefix external/mor1kx https://gi
 git subtree pull -m "Update external/opensocdebug/osd-sw" --prefix external/opensocdebug/software https://github.com/opensocdebug/osd-sw.git master --squash
 
 # opensocdebug/hardware: OSD hardware
-git subtree pull -m "Update external/opensocdebug/osd-hw" --prefix external/opensocdebug/hardware https://github.com/opensocdebug/osd-hw.git osd-next --squash
+git subtree pull -m "Update external/opensocdebug/osd-hw" --prefix external/opensocdebug/hardware https://github.com/opensocdebug/osd-hw.git master --squash
 
 # reapply our changes to the working directory
 [ $WD_HAS_CHANGES == 1 ] && git stash pop


### PR DESCRIPTION
Finalize Spyglass integration for the compute_tile_dm on Nexys 4 DDR by updating all external dependencies to a version which is Spyglass-clean, and enabling the spyglass configuration in the core file.