### PR TITLE
Reworked the noc_buffer

### DIFF
--- a/src/soc/hw/noc/test/test_noc_buffer.manifest.yaml
+++ b/src/soc/hw/noc/test/test_noc_buffer.manifest.yaml
@@ -1,0 +1,22 @@
+module: test_noc_buffer
+
+sources:
+  - ../verilog/noc_buffer.sv
+
+toplevel: noc_buffer
+
+simulators:
+  - vcs
+
+parameters:
+    FLIT_WIDTH: [8,32]
+    DEPTH: [2,4,16]
+
+parameter_includes:
+  - FLIT_WIDTH: 32
+    DEPTH: 8
+  # Test case to test the FULLPACKET feature. The test is hardcoded and only
+  # works with these parameters.
+  - FLIT_WIDTH: 8
+    DEPTH: 4
+    FULLPACKET: 1

--- a/src/soc/hw/noc/test/test_noc_buffer.py
+++ b/src/soc/hw/noc/test/test_noc_buffer.py
@@ -1,0 +1,386 @@
+# Copyright (c) 2019 by the author(s)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# =============================================================================
+#
+# Test for the module 'noc_buffer'
+#
+# Author(s):
+#  - Max Koenen <max.koenen@tum.de>
+#
+
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, FallingEdge
+from cocotb.result import TestFailure
+
+# Mirroring expected contents of the FIFO
+_buffer_flits = []
+_buffer_last = []
+
+@cocotb.test()
+def test_noc_buffer_fullpacket(dut):
+    """
+    Test the module noc_buffer with the fullpacket feature enabled.
+    This test is hardcoded and only works with WIDTH = 8, DEPTH = 4 and
+    FULLPACKET = 1.
+    """
+
+    if (dut.FULLPACKET.value.integer != 1 or dut.FLIT_WIDTH.value.integer != 8 or
+        dut.DEPTH.value.integer != 4):
+        return
+
+    dut._log.info("NoC buffer for a flit width of 8 bits and a depth of 4. " +
+                  "FULLPACKET feature is enabled.")
+
+    yield _init_dut(dut)
+    yield _fullpacket_test_case(dut)
+    dut._log.info("All tests done")
+
+
+@cocotb.test()
+def test_noc_buffer_no_fullpacket(dut):
+    """
+    Test the module noc_buffer with the fullpacket feature disabled.
+    """
+
+    if dut.FULLPACKET.value.integer == 1:
+        return
+
+    width = dut.FLIT_WIDTH.value.integer
+    depth = dut.DEPTH.value.integer
+    dut._log.info("NoC buffer for a flit width of {} bits and a depth of {}. ".format(width, depth) +
+                  "FULLPACKET feature is disabled.")
+
+    yield _init_dut(dut)
+    # Start read and write processes
+    write_thread = cocotb.fork(_write_buffer(dut, dut.clk, width))
+    read_thread = cocotb.fork(_read_buffer(dut, dut.clk))
+    # Wait for read/write to finish. Read only finishes if all required data
+    # has been obtained, i.e. it implicitly waits for write as well.
+    yield read_thread.join()
+    dut._log.info("All tests done")
+
+
+@cocotb.coroutine
+def _init_dut(dut):
+    # Setup clock
+    cocotb.fork(Clock(dut.clk, 10, "ns").start())
+
+    # Reset
+    dut._log.info("Resetting DUT")
+    dut.rst <= 1
+
+    dut.in_flit <= 0
+    dut.in_valid <= 0
+    dut.in_last <= 0
+    dut.out_ready <= 0
+
+    for _ in range(2):
+        yield RisingEdge(dut.clk)
+    dut.rst <= 0
+
+
+@cocotb.coroutine
+def _write_buffer(dut, clk, width, max_delay=5, write_items=1000, write_random_data=True):
+    """
+    Before writing wait between 0 and max_delay cycles.
+    """
+
+    global _buffer_flits, _buffer_last
+
+    wrcnt = 0
+    while True:
+        # Insert random wait before the next write
+        wr_delay = random.randint(0, max_delay)
+        dut._log.debug("WRITE: Wait for {} clock cycles".format(wr_delay))
+        for _ in range(wr_delay):
+            dut.in_valid <= 0
+            yield RisingEdge(clk)
+
+        # Generate and write flit, keep track of it for checking
+        if write_random_data:
+            flit = random.getrandbits(width)
+            last = random.getrandbits(1)
+        else:
+            flit = wrcnt % (2 ** width)
+            last = wrcnt % 2
+        dut.in_flit <= flit
+        dut.in_last <= last
+        dut.in_valid <= 1
+
+        yield RisingEdge(clk)
+
+        # Wait until buffer is ready
+        if dut.in_ready != 1:
+            while dut.in_ready.value.integer != 1:
+                yield RisingEdge(clk)
+
+        _buffer_flits.append(flit)
+        _buffer_last.append(last)
+        wrcnt += 1
+        dut._log.debug("WRITE: Wrote word {} to buffer, value {}, last {}".format(wrcnt, hex(flit), last))
+
+        if wrcnt >= write_items:
+            dut.in_valid <= 0
+            return
+
+
+@cocotb.coroutine
+def _read_buffer(dut, clk, max_delay=5, read_items=1000):
+    """
+    Before the read starts a delay between 0 and max_delay cycles is
+    waited.
+    """
+
+    global _buffer_flits, _buffer_last
+
+    rdcnt = 0
+    while True:
+        # Determine wait cycles before next read
+        rd_delay = random.randint(0, max_delay)
+        dut._log.debug("READ: Wait for {} clock cycles".format(rd_delay))
+        for _ in range(rd_delay):
+            yield RisingEdge(clk)
+        else:
+            dut.out_ready <= 1
+            yield RisingEdge(clk)
+
+        while dut.out_valid.value.integer:
+            # Get current flit and flag
+            flit = dut.out_flit.value.integer
+            last = dut.out_last.value.integer
+            flit_expected = _buffer_flits.pop(0)
+            last_expected = _buffer_last.pop(0)
+            rdcnt += 1
+            dut._log.debug("READ: Read flit {} in read {}.".format(hex(flit), rdcnt))
+
+            # Check read flit and flag
+            if flit_expected != flit or last_expected != last:
+                raise TestFailure("READ: Flit expected {}, read {}, ".format(hex(flit_expected), hex(flit)) +\
+                                  "last expected {}, read {}, at read {}.".format(last_expected, last, rdcnt))
+
+            yield RisingEdge(clk)
+
+        else:
+            dut._log.debug("READ: Buffer empty, not reading")
+            dut.out_ready <= 0
+
+        if rdcnt >= read_items:
+            return
+
+
+@cocotb.coroutine
+def _fullpacket_test_case(dut):
+    """
+    Test case to test FULLPACKET behavior.
+    This test is hardcoded to the parameters:
+        FLIT_WIDTH = 8
+        DEPTH = 4
+        FULLPACKET = 1
+    """
+
+    yield FallingEdge(dut.clk)
+
+    _set_inputs(dut, 0x01, 0, 0, 0)
+    yield FallingEdge(dut.clk)
+
+    # Fill buffer with long packet, then add a second, shorter one while draining
+    # 1) 5 flits: 0x02 0x04 0x05 0x06 0x07
+    # 2) 2 flits: 0x0a 0x0c
+    if dut.out_valid.value.integer:
+        raise TestFailure("Out valid is '1', expected '0'!")
+    _set_inputs(dut, 0x02, 0, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x02, 0, 0, 1, 0)
+    _set_inputs(dut, 0x03, 0, 0, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x02, 0, 0, 1, 0)
+    _set_inputs(dut, 0x04, 0, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x02, 0, 0, 1, 0)
+    _set_inputs(dut, 0x05, 0, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x02, 0, 0, 1, 0)
+    _set_inputs(dut, 0x06, 0, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x02, 0, 0, 1, 0)
+    _set_inputs(dut, 0x07, 1, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x02, 0, 1, 0, 5)
+    _set_inputs(dut, 0x08, 0, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x02, 0, 1, 0, 5)
+    _set_inputs(dut, 0x09, 0, 1, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x04, 0, 1, 1, 4)
+    _set_inputs(dut, 0x0a, 0, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x04, 0, 1, 0, 4)
+    _set_inputs(dut, 0x0b, 0, 1, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x05, 0, 1, 1, 3)
+    _set_inputs(dut, 0x0c, 1, 1, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x06, 0, 1, 1, 2)
+    _set_inputs(dut, 0x0d, 0, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x07, 1, 1, 1, 1)
+    _set_inputs(dut, 0x0e, 0, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x0a, 0, 1, 1, 2)
+    _set_inputs(dut, 0x0f, 0, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x0c, 1, 1, 1, 1)
+    _set_inputs(dut, 0x10, 0, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x0c, 1, 0, 1, 0)
+    _set_inputs(dut, 0x11, 0, 0, 0)
+    yield FallingEdge(dut.clk)
+
+    # Insert a series of different sized packets
+    # 1) 1 flit: 0x12
+    # 2) 3 flits: 0x13 0x14 0x15
+    # 3) 1 flit: 0x16
+    _assert_outputs(dut, 0x0c, 1, 0, 1, 0)
+    _set_inputs(dut, 0x12, 1, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x12, 1, 1, 1, 1)
+    _set_inputs(dut, 0x13, 0, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x12, 1, 1, 1, 1)
+    _set_inputs(dut, 0x14, 0, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x12, 1, 1, 1, 1)
+    _set_inputs(dut, 0x15, 1, 1, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x13, 0, 1, 1, 3)
+    _set_inputs(dut, 0x16, 1, 1, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x14, 0, 1, 1, 2)
+    _set_inputs(dut, 0x17, 0, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x15, 1, 1, 1, 1)
+    _set_inputs(dut, 0x18, 0, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x16, 1, 1, 1, 1)
+    _set_inputs(dut, 0x19, 0, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    # Insert a series of 3 1-flit packets with 1 idle cycle in between and
+    # assure correct timing behavior.
+    # 0x1a 0x1c 0x1e
+    _assert_outputs(dut, 0x16, 1, 0, 1, 0)
+    _set_inputs(dut, 0x1a, 1, 1, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x1a, 1, 1, 1, 1)
+    _set_inputs(dut, 0x1b, 1, 0, 0)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x1a, 1, 1, 1, 1)
+    _set_inputs(dut, 0x1c, 1, 1, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x1c, 1, 1, 1, 1)
+    _set_inputs(dut, 0x1d, 1, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x1c, 1, 0, 1, 0)
+    _set_inputs(dut, 0x1e, 1, 1, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x1e, 1, 1, 1, 1)
+    _set_inputs(dut, 0x1f, 1, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x1e, 1, 0, 1, 0)
+    _set_inputs(dut, 0x1f, 1, 0, 1)
+    yield FallingEdge(dut.clk)
+
+    _assert_outputs(dut, 0x1e, 1, 0, 1, 0)
+    _set_inputs(dut, 0x1f, 1, 0, 1)
+    yield FallingEdge(dut.clk)
+
+
+def _assert_outputs(dut, out_flit, out_last, out_valid, in_ready, packet_size):
+    """
+    Checks if the DUT outputs show the expected values.
+    """
+
+    error = False
+
+    r_out_flit = dut.out_flit.value.integer
+    r_out_last = dut.out_last.value.integer
+    r_out_valid = dut.out_valid.value.integer
+    r_in_ready = dut.in_ready.value.integer
+    r_packet_size = dut.packet_size.value.integer
+    if (r_out_flit != out_flit or r_out_last != out_last or
+        r_out_valid != out_valid or r_in_ready != in_ready or
+        r_packet_size != packet_size):
+        error = True
+
+    dut._log.debug("out_flit: {}; out_last: {}; ".format(hex(r_out_flit), r_out_last) +\
+                   "out_valid: {}; in_ready: {}\n".format(r_out_valid, r_in_ready) +\
+                   "packet_size: {}".format(r_packet_size))
+    if error:
+        raise TestFailure("Comparison error!\nValues expected:\n" +\
+                          "out_flit: {}; out_last: {}; ".format(hex(out_flit), out_last) +\
+                          "out_valid: {}; in_ready: {}\n".format(out_valid, in_ready) +\
+                          "packet_size: {}\n".format(packet_size) +\
+                          "Values read:\n" +\
+                          "out_flit: {}; out_last: {}; ".format(hex(r_out_flit), r_out_last) +\
+                          "out_valid: {}; in_ready: {}\n".format(r_out_valid, r_in_ready) +\
+                          "packet_size: {}\n".format(r_packet_size))
+
+
+def _set_inputs(dut, in_flit, in_last, in_valid, out_ready):
+    """
+    Helper method to set the TDM and BE inputs of the DUT.
+    """
+
+    dut.in_flit <= in_flit
+    dut.in_last <= in_last
+    dut.in_valid <= in_valid
+    dut.out_ready <= out_ready

--- a/src/soc/hw/noc/verilog/noc_buffer.sv
+++ b/src/soc/hw/noc/verilog/noc_buffer.sv
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017 by the author(s)
+/* Copyright (c) 2017-2019 by the author(s)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,97 +25,134 @@
  * Author(s):
  *   Stefan Wallentowitz <stefan@wallentowitz.de>
  *   Wei Song <wsong83@gmail.com>
+ *   Max Koenen <max.koenen@tum.de>
  */
 
-module noc_buffer
-  #(parameter FLIT_WIDTH = 32,
-    parameter DEPTH = 16,
-    parameter FULLPACKET = 0,
+/**
+ * FIFO buffer for NoC use cases
+ *
+ * This FIFO buffer for NoC use cases has 1 clock cycle minimum delay from input
+ * to output and is coded according to the "Vivado User Guide UG901", allowing
+ * it to be synthesized using LUT RAM.
+ * The actual depth is DEPTH + 1 because of the output register stage.
+ * The FIFO provides a feature which will only signal a valid flit at the output
+ * if a full packet is stored inside the buffer (i.e. at least one last-flit is
+ * stored). If this feature is activated (FULLPACKET = 1) the size of the packet
+ * can be read from the 'packet_size' output.
+ */
+module noc_buffer #(
+   parameter FLIT_WIDTH = 32,
+   parameter DEPTH = 16,   // must be a power of 2
+   parameter FULLPACKET = 0,
 
-    localparam ID_W = $clog2(DEPTH) // the width of the index
-   )(
-    input                       clk,
-    input                       rst,
+   localparam AW = $clog2(DEPTH) // the width of the index
+)(
+   input clk,
+   input rst,
 
-    // FIFO input side
-    input [FLIT_WIDTH-1:0]      in_flit,
-    input                       in_last,
-    input                       in_valid,
-    output                      in_ready,
+   // FIFO input side
+   input [FLIT_WIDTH-1:0]        in_flit,
+   input                         in_last,
+   input                         in_valid,
+   output                        in_ready,
 
-    //FIFO output side
-    output reg [FLIT_WIDTH-1:0] out_flit,
-    output reg                  out_last,
-    output reg                  out_valid,
-    input                       out_ready,
+   //FIFO output side
+   output reg [FLIT_WIDTH-1:0]   out_flit,
+   output reg                    out_last,
+   output                        out_valid,
+   input                         out_ready,
 
-    output [ID_W-1:0]           packet_size
-    );
+   output [AW:0]                 packet_size
+);
 
-   // internal shift register
-   reg [DEPTH-1:0][FLIT_WIDTH:0] data;
-   reg [ID_W:0]                     rp; // read pointer
-   logic                            reg_out_valid;  // local output valid
-   logic                            in_fire, out_fire;
+   // Ensure that parameters are set to allowed values
+   initial begin
+      if ((1 << $clog2(DEPTH)) != DEPTH) begin
+         $fatal("noc_buffer: the DEPTH must be a power of two.");
+      end
+   end
 
-   assign in_ready = (rp != DEPTH - 1) || !reg_out_valid;
-   assign in_fire = in_valid && in_ready;
-   assign out_fire = out_valid && out_ready;
+   reg [AW-1:0]   wr_addr;
+   reg [AW-1:0]   rd_addr;
+   reg [AW:0]     rd_count;
+   wire           fifo_read;
+   wire           fifo_write;
+   wire           read_ram;
+   wire           write_through;
+   wire           write_ram;
 
-   always_ff @(posedge clk)
-     if(rst)
-       reg_out_valid <= 0;
-     else if(in_valid)
-       reg_out_valid <= 1;
-     else if(out_fire && rp == 0)
-       reg_out_valid <= 0;
+   assign in_ready = (rd_count < DEPTH + 1); // The actual depth is DEPTH+1 because of the output register
+   assign fifo_read = out_valid & out_ready;
+   assign fifo_write = in_ready & in_valid;
+   assign read_ram = fifo_read & (rd_count > 1);
+   assign write_through = ((rd_count == 0) | ((rd_count == 1) & fifo_read));
+   assign write_ram = fifo_write & ~write_through;
 
-   always_ff @(posedge clk)
-     if(rst)
-       rp <= 0;
-     else if(in_fire && !out_fire && reg_out_valid)
-       rp <= rp + 1;
-     else if(out_fire && !in_fire && rp != 0)
-       rp <= rp - 1;
+   // Address logic
+   always_ff @(posedge clk) begin
+      if (rst) begin
+         wr_addr <= 'b0;
+         rd_addr <= 'b0;
+         rd_count <= 'b0;
+      end else begin
+         if (fifo_write & ~fifo_read)
+            rd_count <=  rd_count + 1'b1;
+         if (fifo_read & ~fifo_write)
+            rd_count <= rd_count - 1'b1;
+         if (write_ram)
+            wr_addr <= wr_addr + 1'b1;
+         if (read_ram)
+            rd_addr <= rd_addr + 1'b1;
+      end
+   end
 
-   always @(posedge clk)
-     if(in_fire)
-       data <= {data, {in_last, in_flit}};
+   // Generic dual-port, single clock memory
+   reg [FLIT_WIDTH:0] ram [DEPTH-1:0];
 
-   generate                     // SRL does not allow parallel read
-      if(FULLPACKET != 0) begin
-         logic [DEPTH-1:0] data_last_buf, data_last_shifted;
+   // Write
+   always_ff @(posedge clk) begin
+      if (write_ram) begin
+         ram[wr_addr] <= {in_last, in_flit};
+      end
+   end
+
+   // Read
+   always_ff @(posedge clk) begin
+      if (read_ram) begin
+         out_flit <= ram[rd_addr][0 +: FLIT_WIDTH];
+         out_last <= ram[rd_addr][FLIT_WIDTH];
+      end else if (fifo_write & write_through) begin
+         out_flit <= in_flit;
+         out_last <= in_last;
+      end
+   end
+
+   generate
+      if (FULLPACKET != 0) begin
+         reg [DEPTH:0] data_last_buf;
+         wire [DEPTH:0] data_last_shifted;
 
          always @(posedge clk)
-           if(rst)
-             data_last_buf <= 0;
-           else if(in_fire)
-             data_last_buf <= {data_last_buf, in_last && in_valid};
+            if (rst)
+               data_last_buf <= 0;
+            else if (fifo_write)
+               data_last_buf <= {data_last_buf, in_last};
 
-         // extra logic to get the packet size in a stable manner
-         assign data_last_shifted = data_last_buf << DEPTH - 1 - rp;
+         // Extra logic to get the packet size in a stable manner
+         assign data_last_shifted = data_last_buf << DEPTH + 1 - rd_count;
 
-         function logic [ID_W:0] find_first_one(input logic [DEPTH-1:0] data);
+         function logic [AW:0] find_first_one(input logic [DEPTH:0] data);
             automatic int i;
-            for(i=DEPTH-1; i>=0; i--)
-              if(data[i]) return i;
-            return DEPTH;
+            for (i = DEPTH; i >= 0; i--)
+               if (data[i]) return i;
+            return DEPTH + 1;
          endfunction // size_count
 
-         assign packet_size = DEPTH - find_first_one(data_last_shifted);
-
-         always_comb begin
-            out_flit = data[rp][FLIT_WIDTH-1:0];
-            out_last = data[rp][FLIT_WIDTH];
-            out_valid = reg_out_valid && |data_last_shifted;
-         end
+         assign out_valid = (rd_count > 0) & |data_last_shifted;
+         assign packet_size = DEPTH + 1 - find_first_one(data_last_shifted);
       end else begin // if (FULLPACKET)
+         assign out_valid = rd_count > 0;
          assign packet_size = 0;
-         always_comb begin
-            out_flit = data[rp][FLIT_WIDTH-1:0];
-            out_last = data[rp][FLIT_WIDTH];
-            out_valid = reg_out_valid;
-         end
       end
    endgenerate
 endmodule // noc_buffer

--- a/src/soc/hw/noc/verilog/noc_buffer_2_cycles.sv
+++ b/src/soc/hw/noc/verilog/noc_buffer_2_cycles.sv
@@ -1,0 +1,165 @@
+/* Copyright (c) 2017-2019 by the author(s)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * =============================================================================
+ *
+ * Buffer for NoC packets
+ *
+ * Author(s):
+ *   Stefan Wallentowitz <stefan@wallentowitz.de>
+ *   Wei Song <wsong83@gmail.com>
+ *   Max Koenen <max.koenen@tum.de>
+ */
+
+/**
+ * FIFO buffer for NoC use cases (2 delay cycle version)
+ *
+ * This FIFO buffer for NoC use cases has 2 clock cycles minimum delay from
+ * input to output and is coded according to the "Vivado User Guide UG901",
+ * allowing it to be synthesized using LUT RAM.
+ * The required logic of this buffer is smaller in comparison to the version
+ * with 1 cycle minimum delay.
+ * The FIFO provides a feature which will only signal a valid flit at the output
+ * if a full packet is stored inside the buffer (i.e. at least one last-flit is
+ * stored). If this feature is activated (FULLPACKET = 1) the size of the packet
+ * can be read from the 'packet_size' output.
+ */
+module noc_buffer #(
+   parameter FLIT_WIDTH = 32,
+   parameter DEPTH = 16,   // must be a power of 2
+   parameter FULLPACKET = 0,
+
+   localparam AW = $clog2(DEPTH) // the width of the index
+)(
+   input clk,
+   input rst,
+
+   // FIFO input side
+   input [FLIT_WIDTH-1:0]        in_flit,
+   input                         in_last,
+   input                         in_valid,
+   output                        in_ready,
+
+   //FIFO output side
+   output reg [FLIT_WIDTH-1:0]   out_flit,
+   output reg                    out_last,
+   output                        out_valid,
+   input                         out_ready,
+
+   output [AW-1:0]               packet_size
+);
+
+   // Ensure that parameters are set to allowed values
+   initial begin
+      if ((1 << $clog2(DEPTH)) != DEPTH) begin
+         $fatal("noc_buffer: the DEPTH must be a power of two.");
+      end
+   end
+
+   reg [AW-1:0]   wr_addr;
+   reg [AW-1:0]   rd_addr_reg;
+   reg [AW-1:0]   rd_count;
+   wire [AW-1:0]  rd_addr;
+   wire           fifo_read;
+   wire           fifo_write;
+   wire           update_out;
+
+   assign in_ready = (rd_count < (DEPTH-1));
+   assign rd_addr = fifo_read ? rd_addr_reg + 1'b1 : rd_addr_reg;
+   assign fifo_read = out_valid & out_ready;
+   assign fifo_write = in_ready & in_valid;
+   assign update_out = (rd_count == 1) | fifo_read;
+
+   // Address logic
+   always_ff @(posedge clk) begin
+      if (rst) begin
+         wr_addr <= 'b0;
+         rd_addr_reg <= 'b0;
+         rd_count <= 'b0;
+      end else begin
+         if (fifo_write & fifo_read) begin
+            wr_addr <= wr_addr + 1'b1;
+            rd_addr_reg <= rd_addr_reg + 1'b1;
+         end else if (fifo_write) begin
+            wr_addr <= wr_addr + 1'b1;
+            rd_count <= rd_count + 1'b1;
+         end else if (fifo_read) begin
+            rd_addr_reg <= rd_addr_reg + 1'b1;
+            rd_count <= rd_count - 1'b1;
+         end
+      end
+   end
+
+   // Generic dual-port, single clock memory
+   reg [FLIT_WIDTH:0] ram [DEPTH-1:0];
+
+   // Write
+   always_ff @(posedge clk) begin
+      if (fifo_write) begin
+         ram[wr_addr] <= {in_last, in_flit};
+      end
+   end
+
+   // Read
+   always_ff @(posedge clk) begin
+      if (update_out) begin
+         out_flit <= ram[rd_addr][0 +: FLIT_WIDTH];
+         out_last <= ram[rd_addr][FLIT_WIDTH];
+      end
+   end
+
+   generate
+      if (FULLPACKET != 0) begin
+         reg [DEPTH-1:0] data_last_buf;
+         wire [DEPTH-1:0] data_last_shifted;
+         reg nxt_out_valid;
+
+         always @(posedge clk)
+            if (rst)
+               data_last_buf <= 0;
+            else if (fifo_write)
+               data_last_buf <= {data_last_buf, in_last};
+
+         // Extra logic to get the packet size in a stable manner
+         assign data_last_shifted = data_last_buf << DEPTH - 1 - (rd_count-1);
+
+         function logic [AW:0] find_first_one(input logic [DEPTH-1:0] data);
+            automatic int i;
+            for (i = DEPTH-1; i >= 0; i--)
+               if (data[i]) return i;
+                  return DEPTH;
+         endfunction // size_count
+
+         // Delay out_valid signal by one cycle to match flit delay
+         always @(posedge clk)
+            nxt_out_valid <= (rd_count > 1 || (rd_count == 1 && ~fifo_read)) && |data_last_shifted;
+
+         assign out_valid = nxt_out_valid;
+         assign packet_size = DEPTH - find_first_one(data_last_shifted);
+      end else begin // if (FULLPACKET)
+         reg nxt_out_valid;
+         // Delay out_valid signal by one cycle to match flit delay
+         always @(posedge clk)
+            nxt_out_valid <= (rd_count > 1 || (rd_count == 1 && ~fifo_read));
+         assign out_valid = nxt_out_valid;
+         assign packet_size = 0;
+      end
+   endgenerate
+endmodule // noc_buffer


### PR DESCRIPTION
The noc_buffer is now using RAM for the flits and last flags instead of a shift register. A shift register is still used to generate the full packet information.

So far I tested it with the system_2x2_cccc_sim in Verilator and the hello_mpsimple application and it seems to work. Haven't tried synthesizing yet.
@wallento @imphil could you have a look whether this makes sense to you or whether you suggest changes? (regarding #72 )