### PR TITLE
Fixed bug in noc_mux module

### DIFF
--- a/src/soc/hw/mpbuffer/verilog/mpbuffer_endpoint.sv
+++ b/src/soc/hw/mpbuffer/verilog/mpbuffer_endpoint.sv
@@ -77,7 +77,7 @@ module mpbuffer_endpoint
 
    import optimsoc_functions::*;
 
-   localparam SIZE_WIDTH = clog2_width(SIZE);
+   localparam SIZE_WIDTH = clog2_width(SIZE+1);
 
    // Connect from the outgoing state machine to the packet buffer
    wire [CONFIG.NOC_FLIT_WIDTH-1:0] out_flit;

--- a/src/soc/hw/noc/verilog/noc_mux.sv
+++ b/src/soc/hw/noc/verilog/noc_mux.sv
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017 by the author(s)
+/* Copyright (c) 2015-2019 by the author(s)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -82,10 +82,10 @@ module noc_mux
          end
       end else begin
          out_valid = 0;
-         if (|in_valid) begin
+         if (|in_valid && out_ready) begin
             out_valid = 1'b1;
             nxt_activeroute = ~out_last;
-            in_ready = select & {CHANNELS{out_ready}};
+            in_ready = select;
          end
       end
    end // always @ (*)


### PR DESCRIPTION
The bug would occur when 'activeroute' is zero, 'out_ready' is zero,
and 'in_valid' in non-zero. In this case 'activeroute' would be set but
the 'active' signals would never be updated (because 'req_masked' always
remains zero), causig the module to be stuck to the current channel, until
another last flit arrives on that channel.

@wallento, @imphil, does this make sense to you?