### PR TITLE
Work around cairocffi not being installable by setuptools

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,11 +6,17 @@ all: html
 $(OBJDIR)/.venv: requirements.txt
 	python3 -m venv $(OBJDIR)/.venv
 	$(OBJDIR)/.venv/bin/pip install --upgrade pip
-	# cairocffi 1.0 (a dependency of cairosvg) requires a newer setuptools
-	# than Ubuntu 16.04 provides. Error message during "pip install":
-	# "Generating metadata for package cairocffi produced metadata for project
-	# name unknown. Fix your #egg=cairocffi fragments."
-	$(OBJDIR)/.venv/bin/pip install --upgrade setuptools
+	# Work around deficiencies in the pip dependency resolver to install
+	# cairocffi
+	#
+	# - cairocffi 1.0 (a dependency of cairosvg) requires a newer setuptools
+	#   than Ubuntu 16.04 provides. Error message during "pip install":
+	#   "Generating metadata for package cairocffi produced metadata for
+	#   project name unknown. Fix your #egg=cairocffi fragments."
+	#   This version needs to be installed before requirements.txt is installed
+	#   as package metadata is not parsed correctly otherwise.
+	# - cairocffi and setuptools >= 42.0.0 need to have wheel pre-installed.
+	$(OBJDIR)/.venv/bin/pip install --upgrade 'setuptools >= 39.2.0' wheel
 	$(OBJDIR)/.venv/bin/pip install --upgrade -r requirements.txt
 
 apidoc: $(OBJDIR)/.venv


### PR DESCRIPTION
setuptools 42.0.0 and 42.0.1 isn't able to install cairocffi, work
around that by disallowing any 42.0.* version for now.

Fixes #184